### PR TITLE
Fix issue #119: ZMQ packet parsing for python2

### DIFF
--- a/larpix/io/zmq_io.py
+++ b/larpix/io/zmq_io.py
@@ -1,5 +1,6 @@
 import time
 import zmq
+import sys
 
 from larpix.io import IO
 from larpix.larpix import Packet
@@ -120,7 +121,11 @@ class ZMQ_IO(IO):
         '''
         Encode a list of packets into ZMQ messages
         '''
-        msg_data = [b'0x00%s 0' % packet.bytes()[::-1].hex().encode() for packet in packets]
+        msg_data = []
+        if sys.version_info[0] < 3:
+            msg_data = [b'0x00%s 0' % packet.bytes()[::-1].encode('hex') for packet in packets]
+        else:
+            msg_data = [b'0x00%s 0' % packet.bytes()[::-1].hex().encode() for packet in packets]
         return msg_data
 
     def empty_queue(self):

--- a/test/test_zmq_io.py
+++ b/test/test_zmq_io.py
@@ -1,0 +1,19 @@
+'''
+Tests for larpix.io.zmq_io module
+
+'''
+from __future__ import print_function
+import pytest
+import os
+from larpix.larpix import Packet
+from larpix.io.zmq_io import ZMQ_IO
+
+def test_encode():
+    test_bytes = b'\x00\x01\x02\x03\x04\x05\x06'
+    expected = [b'0x0006050403020100 0']
+    assert ZMQ_IO.encode([Packet(test_bytes)]) == expected
+
+def test_decode():
+    test_bytes = b'\x00\x06\x05\x04\x03\x02\x01\x00'
+    expected = [Packet(test_bytes[:-1])]
+    assert ZMQ_IO.decode([test_bytes]) == expected


### PR DESCRIPTION
Fixed bug that raised an error when encoding packets while using python 2.
Adds a test for encoding / decoding ZMQ IO messages.