### PR TITLE
Fis issue 115: Ignore irrelevant IO warning in logger tests

### DIFF
--- a/test/test_h5_logger.py
+++ b/test/test_h5_logger.py
@@ -83,6 +83,7 @@ def test_record():
     logger.record([Packet()], timestamp=5.0)
     assert logger._buffer['raw_packet'][0] == HDF5Logger.encode(Packet(), timestamp=5.0)
 
+@pytest.mark.filterwarnings("ignore:no IO object")
 @fresh_temp_file
 def test_controller_write_capture():
     controller = Controller()

--- a/test/test_stdout_logger.py
+++ b/test/test_stdout_logger.py
@@ -61,6 +61,7 @@ def test_record():
     logger.record(['test'], timestamp=5.0)
     assert logger._buffer[0] == 'Record 5.0: test'
 
+@pytest.mark.filterwarnings("ignore:no IO object")
 def test_controller_write_capture(capfd):
     controller = Controller()
     controller.logger = StdoutLogger(buffer_length=1)


### PR DESCRIPTION
Fix for issue 115 - tests in logger should ignore warning related to missing IO object.