### PR TITLE
Fix issues with copying files during pip install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ python:
     - "3.6"
     - "2.7"
 install:
-    - pip install -e .
+    - pip install .
 script: pytest

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,0 @@
-include fpga_interface.txt
-include larpix/configs/*.json
-include larpix/configs/chip/*.json
-include larpix/configs/chain/*.json
-include VERSION

--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,8 @@ setup(
             'numpy ~= 1.16',
             'h5py ~= 2.9'
             ],
-        include_package_data=True,
+        package_data={
+            'larpix.configs.chip': 'configs/chip/*.json',
+            'larpix.configs.controller': 'configs/controller/*.json',
+            },
 )


### PR DESCRIPTION
Removed the MANIFEST.in file in favor of the more modern and precise package_data argument to setup.py. Fixed the travis-ci testing configuration which was unable to catch this type of error because it was running ``pip install -e .`` rather than ``pip install .`` and so was not checking for copied files.