### PR TITLE
Successfully override safe mode in controller.load

### DIFF
--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -982,7 +982,7 @@ class Controller(object):
         :param filename: File path to configuration file
         :param safe: Flag to check chip keys against current io
         '''
-        return self.load_controller(filename, safe=True)
+        return self.load_controller(filename, safe=safe)
 
     def load_controller(self, filename, safe=True):
         '''

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -1530,6 +1530,21 @@ def test_controller_send(capfd):
     expected = list_of_packets_str(to_send)
     assert result == expected
 
+def test_controller_load():
+    controller = Controller()
+    controller.io = FakeIO()
+    controller.load('controller/pcb-1_chip_info.json')
+
+def test_controller_load_safe_catch():
+    controller = Controller()
+    with pytest.raises(RuntimeError):
+        controller.load('controller/pcb-1_chip_info.json')
+        pytest.fail("Should raise error since there's no IO object"
+                " to check if keys are valid")
+
+def test_controller_load_safe_override():
+    controller = Controller()
+    controller.load('controller/pcb-1_chip_info.json', safe=False)
 
 def test_controller_read_configuration(capfd):
     controller = Controller()


### PR DESCRIPTION
Previously there was a hardcoded ``True`` in the implementation of controller.load. That is fixed and now there is a test to catch that error.