### PR TITLE
HDF5 file format + TimestampPacket

### DIFF
--- a/docs/api/format/hdf5format.rst
+++ b/docs/api/format/hdf5format.rst
@@ -1,0 +1,4 @@
+LArPix+HDF5 Format
+==================
+
+.. automodule:: larpix.format.hdf5format

--- a/docs/api/format/hdf5format.rst
+++ b/docs/api/format/hdf5format.rst
@@ -2,3 +2,11 @@ LArPix+HDF5 Format
 ==================
 
 .. automodule:: larpix.format.hdf5format
+   :no-members:
+   :members: to_file, from_file
+
+   .. autodata:: larpix.format.hdf5format.latest_version
+   .. autodata:: larpix.format.hdf5format.dtypes
+     :annotation:
+   .. autodata:: larpix.format.hdf5format.dtype_property_index_lookup
+     :annotation:

--- a/docs/api/format/index.rst
+++ b/docs/api/format/index.rst
@@ -1,0 +1,11 @@
+LArPix Formats
+==============
+
+The data formats used for LArPix are:
+
+.. toctree::
+   :maxdepth: 2
+
+   hdf5format
+
+:ref:`genindex`

--- a/docs/api/logger/index.rst
+++ b/docs/api/logger/index.rst
@@ -1,7 +1,7 @@
 LArPix Logger
 =============
 
-.. autoclass:: larpix.logger.Logger
+.. automodule:: larpix.logger
 
 Implementations
 ^^^^^^^^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,5 +15,6 @@ Here is the documentation for LArPix Control.
    api/io/index
    api/configs/index
    api/logger/index
+   api/format/index
 
 :ref:`genindex`

--- a/larpix/format/hdf5format.py
+++ b/larpix/format/hdf5format.py
@@ -5,7 +5,15 @@ File format description
 =======================
 
 All LArPix+HDF5 files use the HDF5 format so that they
-can be read and written using any language that has an HDF5 binding.
+can be read and written using any language that has an HDF5 binding. The
+documentation for the Python h5py binding is at <http://docs.h5py.org>.
+
+The ``to_file`` and ``from_file`` methods translate between a list of
+Packet-like objects and an HDF5 data file. ``from_file`` can be used to
+load up the full file all at once or just a subset of rows (supposing
+the full file was too big to fit in memory). To access the data most
+efficiently, do not rely on ``from_file`` and instead perform analysis
+directly on the HDF5 data file.
 
 File Header
 -----------
@@ -134,6 +142,31 @@ packets in the ``packets`` dataset.
         - ``index`` (``u4``/unsigned 4-byte int): the message index,
           which should be equal to the row index in the ``messages``
           dataset
+
+Examples
+--------
+
+Plot a histogram of ADC counts (selecting packet type to be data packets
+only)
+
+>>> import matplotlib.pyplot as plt
+>>> import h5py
+>>> f = h5py.File('output.h5', 'r')
+>>> packets = f['packets']
+>>> plt.hist(packets['adc_counts'][packets['type'] == 0])
+>>> plt.show()
+
+Load the first 10 packets in a file into Packet objects and print any
+MessagePacket packets to the console
+
+>>> from larpix.format.hdf5format import from_file
+>>> from larpix.larpix import MessagePacket
+>>> result = from_file('output.h5', end=10)
+>>> for packet in result['packets']:
+...     if isinstance(packet, MessagePacket):
+...         print(packet)
+
+
 
 '''
 import time

--- a/larpix/format/hdf5format.py
+++ b/larpix/format/hdf5format.py
@@ -1,22 +1,24 @@
 import time
 
 import h5py
+import numpy as np
+
+from larpix.larpix import Packet
 
 dtype = [
-        ('record_timestamp', 'f8')
         ('chip_key','S32'),
-        ('type','i8'),
-        ('chipid','i8'),
-        ('parity','i1'),
-        ('valid_parity','i1'),
-        ('counter','i8'),
-        ('channel','i8'),
-        ('timestamp','i8'),
-        ('adc_counts','i8'),
-        ('fifo_half','i1'),
-        ('fifo_full','i1'),
-        ('register','i8'),
-        ('value','i8')
+        ('type','S12'),
+        ('chipid','u1'),
+        ('parity','u1'),
+        ('valid_parity','u1'),
+        ('counter','u4'),
+        ('channel','u1'),
+        ('timestamp','u8'),
+        ('adc_counts','u1'),
+        ('fifo_half','u1'),
+        ('fifo_full','u1'),
+        ('register','u1'),
+        ('value','u1')
         ]
 
 def to_file(filename, packet_list):
@@ -27,10 +29,49 @@ def to_file(filename, packet_list):
         header.attrs['created'] = time.time()
 
         # Create dataset
-        dset = f.create_dataset('raw_packet' shape=(len(packet_list),), maxshape=(None,),
+        dset = f.create_dataset('raw_packet', shape=(len(packet_list),), maxshape=(None,),
                 dtype=dtype)
 
         # Fill dataset
+        encoded_packets = []
         for packet in packet_list:
             dict_rep = packet.export()
+            encoded_packets.append(tuple(
+                (dict_rep.get(key, 0) for key, _ in dtype)))
+        dset[:] = encoded_packets
 
+def from_file(filename):
+    with h5py.File(filename, 'r') as f:
+        if f['_header'].attrs['version'] != '0.0':
+            raise RuntimeError('Invalid version (should be 0.0): %s' %
+                    f['_header'].attrs['version'])
+        packets = []
+        for row in f['raw_packet']:
+            p = Packet()
+            p.type = {
+                    b'data': Packet.DATA_PACKET,
+                    b'test': Packet.TEST_PACKET,
+                    b'config write': Packet.CONFIG_WRITE_PACKET,
+                    b'config read': Packet.CONFIG_READ_PACKET,
+                    }[row[1]]
+            p.chip_key = row[0]
+            p.chipid = row[2]
+            p.parity = row[3]
+            if p.type == Packet.DATA_PACKET:
+                p.channel = row[6]
+                p.timestamp = row[7]
+                p.dataword = row[8]
+                p.fifo_half_flag = row[9]
+                p.fifo_full_flag = row[10]
+            elif p.type == Packet.TEST_PACKET:
+                p.counter = row[5]
+            elif (p.type == Packet.CONFIG_WRITE_PACKET
+                    or p.type == Packet.CONFIG_READ_PACKET):
+                p.register_address = row[11]
+                p.register_data = row[12]
+            packets.append(p)
+        return {
+                'packets': packets,
+                'created': f['_header'].attrs['created'],
+                'version': f['_header'].attrs['version'],
+                }

--- a/larpix/format/hdf5format.py
+++ b/larpix/format/hdf5format.py
@@ -154,7 +154,7 @@ def from_file(filename):
         packets = []
         for row in f['raw_packet']:
             if row[1] == 4:
-                packets.append(TimestampPacket(row[7]))
+                packets.append(TimestampPacket(row[6]))
                 continue
             if row[1] == 5:
                 packets.append(DirectionPacket(row[13]))
@@ -163,7 +163,7 @@ def from_file(filename):
             p.chip_key = row[0]
             p.packet_type = row[1]
             p.chipid = row[2]
-            p.parity = row[3]
+            p.parity_bit_value = row[3]
             if p.packet_type == Packet.DATA_PACKET:
                 p.channel = row[5]
                 p.timestamp = row[6]
@@ -180,5 +180,6 @@ def from_file(filename):
         return {
                 'packets': packets,
                 'created': f['_header'].attrs['created'],
+                'modified': f['_header'].attrs['modified'],
                 'version': f['_header'].attrs['version'],
                 }

--- a/larpix/format/hdf5format.py
+++ b/larpix/format/hdf5format.py
@@ -83,7 +83,7 @@ import time
 import h5py
 import numpy as np
 
-from larpix.larpix import Packet, TimestampPacket, DirectionPacket
+from larpix.larpix import Packet, TimestampPacket
 
 # {version: {dset_name: [structured dtype fields]}}
 dtypes = {
@@ -114,8 +114,8 @@ def to_file(filename, packet_list, mode='a', version='0.0'):
     This method can be used to update an existing file.
 
     :param filename: the name of the file to save to
-    :param packet_list: any iterable of objects of type ``Packet``,
-        ``TimestampPacket``, or ``DirectionPacket``.
+    :param packet_list: any iterable of objects of type ``Packet`` or
+        ``TimestampPacket``.
     :param mode: optional, the "file mode" to open the data file
         (default: ``'a'``)
     :param version: optional, the LArPix+HDF5 format version to use (for
@@ -143,7 +143,6 @@ def to_file(filename, packet_list, mode='a', version='0.0'):
 2: 'config write',
 3: 'config read',
 4: 'timestamp',
-5: 'direction',
 '''
             start_index = 0
         else:
@@ -179,9 +178,6 @@ def from_file(filename):
             if row[1] == 4:
                 packets.append(TimestampPacket(row[6]))
                 continue
-            if row[1] == 5:
-                packets.append(DirectionPacket(row[13]))
-                continue
             p = Packet()
             p.chip_key = row[0]
             p.packet_type = row[1]
@@ -199,6 +195,7 @@ def from_file(filename):
                     or p.packet_type == Packet.CONFIG_READ_PACKET):
                 p.register_address = row[10]
                 p.register_data = row[11]
+            p.direction = row[13]
             packets.append(p)
         return {
                 'packets': packets,

--- a/larpix/format/hdf5format.py
+++ b/larpix/format/hdf5format.py
@@ -1,0 +1,36 @@
+import time
+
+import h5py
+
+dtype = [
+        ('record_timestamp', 'f8')
+        ('chip_key','S32'),
+        ('type','i8'),
+        ('chipid','i8'),
+        ('parity','i1'),
+        ('valid_parity','i1'),
+        ('counter','i8'),
+        ('channel','i8'),
+        ('timestamp','i8'),
+        ('adc_counts','i8'),
+        ('fifo_half','i1'),
+        ('fifo_full','i1'),
+        ('register','i8'),
+        ('value','i8')
+        ]
+
+def to_file(filename, packet_list):
+    with h5py.File(filename, 'w') as f:
+        # Create header
+        header = f.create_group('_header')
+        header.attrs['version'] = '0.0'
+        header.attrs['created'] = time.time()
+
+        # Create dataset
+        dset = f.create_dataset('raw_packet' shape=(len(packet_list),), maxshape=(None,),
+                dtype=dtype)
+
+        # Fill dataset
+        for packet in packet_list:
+            dict_rep = packet.export()
+

--- a/larpix/format/hdf5format.py
+++ b/larpix/format/hdf5format.py
@@ -1,3 +1,81 @@
+'''
+This module gives access to the LArPix+HDF5 file format.
+
+File format description
+=======================
+
+All LArPix+HDF5 files use the HDF5 format so that they
+can be read and written using any language that has an HDF5 binding.
+
+LArPix+HDF5 files are self-describing in that they contain a format
+version which identifies the structure of the file.
+
+File Header
+-----------
+
+The file header can be found in the ``/_header`` HDF5 group. At a
+minimum, the header will contain the following HDF5 attributes:
+
+    - ``version``: a string containing the LArPix+HDF5 version
+    - ``created``: a Unix timestamp of the file's creation time
+    - ``modified``: a Unix timestamp of the files last-modified time
+
+File Data
+---------
+
+The file data is saved in HDF5 datasets, and the specific data format
+depends on the LArPix+HDF5 version.
+
+For version 0.0, there is only one dataset: ``raw_packet``. This dataset
+contains a list of all of the packets sent and received during a
+particular time interval.
+
+    - Shape: ``(N,)``, ``N >= 0``
+
+    - Datatype: a compound datatype (called "structured type" in
+      h5py/numpy). Not all fields are relevant for each packet. Unused
+      fields are set to a default value of 0 or the empty string.
+      Keys/fields:
+
+        - ``chip_key`` (``S32``/32-character string): the chip key
+          identifying the ASIC associated with this packet
+
+        - ``type`` (``S12``/12-character string): a text representation
+          of the packet type (data, test, config read, config write, or
+          timestamp)
+
+        - ``chipid`` (``u1``/unsigned byte): the LArPix chipid
+
+        - ``parity`` (``u1``/unsigned byte): the packet parity bit (0 or
+          1)
+
+        - ``valid_parity`` (``u1``/unsigned byte): 1 if the packet
+          parity is valid (odd), 0 if it is invalid
+
+        - ``counter`` (``u4``/unsigned 4-byte int): the test counter
+          value
+
+        - ``channel`` (``u1``/unsigned byte): the ASIC channel
+
+        - ``timestamp`` (``u8``/unsigned 8-byte long int): the timestamp
+          associated with the packet
+
+        - ``adc_counts`` (``u1``/unsigned byte): the ADC data word
+
+        - ``fifo_half`` (``u1``/unsigned byte): 1 if the FIFO half full
+          flag is present, 0 otherwise.
+
+        - ``fifo_full`` (``u1``/unsigned byte): 1 if the FIFO full flag
+          is present, 0 otherwise.
+
+        - ``register`` (``u1``/unsigned byte): the configuration
+          register index
+
+        - ``value`` (``u1``/unsigned byte): the configuration register
+          value
+
+
+'''
 import time
 
 import h5py
@@ -26,7 +104,7 @@ dtypes = {
             }
         }
 
-def to_file(filename, packet_list, mode='a', version='0.0'):
+def to_file(filename, packet_list, mode='a', version='1.0'):
     with h5py.File(filename, mode) as f:
         # Create header
         if '_header' not in f.keys():

--- a/larpix/format/hdf5format.py
+++ b/larpix/format/hdf5format.py
@@ -3,7 +3,7 @@ import time
 import h5py
 import numpy as np
 
-from larpix.larpix import Packet
+from larpix.larpix import Packet, TimestampPacket
 
 dtype = [
         ('chip_key','S32'),
@@ -47,6 +47,9 @@ def from_file(filename):
                     f['_header'].attrs['version'])
         packets = []
         for row in f['raw_packet']:
+            if row[1] == b'timestamp':
+                packets.append(TimestampPacket(row[7]))
+                continue
             p = Packet()
             p.type = {
                     b'data': Packet.DATA_PACKET,

--- a/larpix/format/hdf5format.py
+++ b/larpix/format/hdf5format.py
@@ -40,9 +40,9 @@ particular time interval.
         - ``chip_key`` (``S32``/32-character string): the chip key
           identifying the ASIC associated with this packet
 
-        - ``type`` (``S12``/12-character string): a text representation
-          of the packet type (data, test, config read, config write, or
-          timestamp)
+        - ``type`` (``u1``/unsigned byte): the packet type code, which
+          can be interpreted according to the map stored in the
+          raw_packet attribute 'packet_types'
 
         - ``chipid`` (``u1``/unsigned byte): the LArPix chipid
 
@@ -88,7 +88,7 @@ dtypes = {
         '0.0': {
             'raw_packet': [
                 ('chip_key','S32'),
-                ('type','S12'),
+                ('type','u1'),
                 ('chipid','u1'),
                 ('parity','u1'),
                 ('valid_parity','u1'),
@@ -120,6 +120,13 @@ def to_file(filename, packet_list, mode='a', version='0.0'):
         if 'raw_packet' not in f.keys():
             dset = f.create_dataset('raw_packet', shape=(len(packet_list),),
                     maxshape=(None,), dtype=dtype)
+            dset.attrs['packet_types'] = '''
+0: 'data',
+1: 'test',
+2: 'config write',
+3: 'config read',
+4: 'timestamp',
+'''
             start_index = 0
         else:
             dset = f['raw_packet']

--- a/larpix/format/hdf5format.py
+++ b/larpix/format/hdf5format.py
@@ -327,7 +327,7 @@ def to_file(filename, packet_list, mode='a', version=None):
             message_dset.resize(message_start_index + len(messages), axis=0)
             message_dset[message_start_index:] = messages
 
-def from_file(filename, version=None):
+def from_file(filename, version=None, start=None, end=None):
     '''
     Read the data from the given file into LArPix Packet objects.
 
@@ -342,6 +342,9 @@ def from_file(filename, version=None):
         the same major version and at least the same minor version. E.g.
         for ``'~1.5'``, versions between v1.5 and v2.0 are compatible.
         If unspecified or ``None``, will use the stored format version.
+    :param start: the index of the first row to read
+    :param end: the index after the last row to read (same semantics as
+        Python ``range``)
     :returns packet_dict: a dict with keys ``'packets'`` containing a
         list of packet objects; and ``'created'``, ``'modified'``, and
         ``'version'``, containing the file metadata.
@@ -378,7 +381,11 @@ def from_file(filename, version=None):
             message_dset = f[message_dset_name]
         props = dtype_property_index_lookup[version][dset_name]
         packets = []
-        for row in f[dset_name]:
+        if start is None and end is None:
+            dset_iter = f[dset_name]
+        else:
+            dset_iter = f[dset_name][start:end]
+        for row in dset_iter:
             if row[props['type']] == 4:
                 packets.append(TimestampPacket(row[props['timestamp']]))
                 continue

--- a/larpix/format/hdf5format.py
+++ b/larpix/format/hdf5format.py
@@ -78,7 +78,10 @@ particular time interval.
         - ``channel`` (``u1``/unsigned byte): the ASIC channel
 
         - ``timestamp`` (``u8``/unsigned 8-byte long int): the timestamp
-          associated with the packet
+          associated with the packet. **Caution**: this field does
+          "double duty" as both the ASIC timestamp in data packets
+          (``type`` == 0), and as the global timestamp in timestamp
+          packets (``type`` == 4).
 
         - ``adc_counts`` (``u1``/unsigned byte): the ADC data word
 
@@ -99,6 +102,18 @@ particular time interval.
 
         - ``direction`` (``u1``/unsigned byte): 0 if packet was sent to
           ASICs, 1 if packet was received from ASICs.
+
+    - Packet types lookup: the ``packets`` dataset has an attribute
+      ``'packet_types'`` which contains the following lookup table for
+      packets::
+
+        0: 'data',
+        1: 'test',
+        2: 'config write',
+        3: 'config read',
+        4: 'timestamp',
+
+
 
 '''
 import time

--- a/larpix/format/hdf5format.py
+++ b/larpix/format/hdf5format.py
@@ -108,6 +108,20 @@ dtypes = {
         }
 
 def to_file(filename, packet_list, mode='a', version='0.0'):
+    '''
+    Save the given packets to the given file.
+
+    This method can be used to update an existing file.
+
+    :param filename: the name of the file to save to
+    :param packet_list: any iterable of objects of type ``Packet``,
+        ``TimestampPacket``, or ``DirectionPacket``.
+    :param mode: optional, the "file mode" to open the data file
+        (default: ``'a'``)
+    :param version: optional, the LArPix+HDF5 format version to use (for
+        backwards compatibility pick an earlier version) (default: '0.0')
+
+    '''
     with h5py.File(filename, mode) as f:
         # Create header
         if '_header' not in f.keys():
@@ -147,6 +161,15 @@ def to_file(filename, packet_list, mode='a', version='0.0'):
         dset[start_index:] = encoded_packets
 
 def from_file(filename):
+    '''
+    Read the data from the given file into LArPix Packet objects.
+
+    :param filename: the name of the file to read
+    :returns packet_dict: a dict with keys ``'packets'`` containing a
+        list of packet objects; and ``'created'``, ``'modified'``, and
+        ``'version'``, containing the file metadata.
+
+    '''
     with h5py.File(filename, 'r') as f:
         if f['_header'].attrs['version'] != '0.0':
             raise RuntimeError('Invalid version (should be 0.0): %s' %

--- a/larpix/format/hdf5format.py
+++ b/larpix/format/hdf5format.py
@@ -104,7 +104,7 @@ dtypes = {
             }
         }
 
-def to_file(filename, packet_list, mode='a', version='1.0'):
+def to_file(filename, packet_list, mode='a', version='0.0'):
     with h5py.File(filename, mode) as f:
         # Create header
         if '_header' not in f.keys():

--- a/larpix/format/hdf5format.py
+++ b/larpix/format/hdf5format.py
@@ -7,9 +7,6 @@ File format description
 All LArPix+HDF5 files use the HDF5 format so that they
 can be read and written using any language that has an HDF5 binding.
 
-LArPix+HDF5 files are self-describing in that they contain a format
-version which identifies the structure of the file.
-
 File Header
 -----------
 
@@ -18,7 +15,33 @@ minimum, the header will contain the following HDF5 attributes:
 
     - ``version``: a string containing the LArPix+HDF5 version
     - ``created``: a Unix timestamp of the file's creation time
-    - ``modified``: a Unix timestamp of the files last-modified time
+    - ``modified``: a Unix timestamp of the file's last-modified time
+
+Versions
+--------
+
+The LArPix+HDF5 format is self-describing and versioned. This means as
+the format evolves, the files themselves will identify which version
+of the format should be used to interpret them. When writing a file
+with ``to_file``, the format version can be specified, or by default,
+the latest version is used. When reading a file with ``from_file``, by
+default, the format version of the actual file is used. If a specific
+format version is expected or required, that version can be specified,
+and a ``RuntimeError`` will be raised if a different format version is
+encountered.
+
+The versions are always in the format ``major.minor`` and are stored as
+strings (e.g. ``'1.0'``, ``'1.5'``).
+
+The minor format will increase if a non-breaking change is made, so that
+a script compatible with a lower minor version will also work with files
+that have a higher minor version. E.g. a script designed to work with
+v1.0 will also work with v1.5. The reverse is not necessarily true: a
+script designed to work with v1.5 *may not* work with v1.0 files.
+
+The major format will increase if a breaking change is made. This means
+that a script designed to work with v1.5 will *likely not* work with
+v2.0 files, and vice versa.
 
 File Data
 ---------
@@ -26,7 +49,7 @@ File Data
 The file data is saved in HDF5 datasets, and the specific data format
 depends on the LArPix+HDF5 version.
 
-For version 0.0, there is only one dataset: ``raw_packet``. This dataset
+For version 1.0, there is only one dataset: ``packets``. This dataset
 contains a list of all of the packets sent and received during a
 particular time interval.
 
@@ -85,10 +108,32 @@ import numpy as np
 
 from larpix.larpix import Packet, TimestampPacket
 
-# {version: {dset_name: [structured dtype fields]}}
+#: The most recent / up-to-date LArPix+HDF5 format version
+latest_version = '1.0'
+
+#: The dtype specification used in the HDF5 files.
+#:
+#: Structure: ``{version: {dset_name: [structured dtype fields]}}``
 dtypes = {
         '0.0': {
             'raw_packet': [
+                ('chip_key','S32'),
+                ('type','u1'),
+                ('chipid','u1'),
+                ('parity','u1'),
+                ('valid_parity','u1'),
+                ('counter','u4'),
+                ('channel','u1'),
+                ('timestamp','u8'),
+                ('adc_counts','u1'),
+                ('fifo_half','u1'),
+                ('fifo_full','u1'),
+                ('register','u1'),
+                ('value','u1'),
+                ]
+            },
+        '1.0': {
+            'packets': [
                 ('chip_key','S32'),
                 ('type','u1'),
                 ('chipid','u1'),
@@ -107,7 +152,49 @@ dtypes = {
             }
         }
 
-def to_file(filename, packet_list, mode='a', version='0.0'):
+#: A map between attribute name and "column index" in the structured
+#: dtypes.
+#:
+#: Structure: ``{version: {dset_name: {field_name: index}}}``
+dtype_property_index_lookup = {
+        '0.0': {
+            'raw_packet': {
+                'chip_key': 0,
+                'type': 1,
+                'chipid': 2,
+                'parity': 3,
+                'valid_parity': 4,
+                'counter': 5,
+                'channel': 6,
+                'timestamp': 7,
+                'adc_counts': 8,
+                'fifo_half': 9,
+                'fifo_full': 10,
+                'register': 11,
+                'value': 12,
+                }
+            },
+        '1.0': {
+            'packets': {
+                'chip_key': 0,
+                'type': 1,
+                'chipid': 2,
+                'parity': 3,
+                'valid_parity': 4,
+                'channel': 5,
+                'timestamp': 6,
+                'adc_counts': 7,
+                'fifo_half': 8,
+                'fifo_full': 9,
+                'register': 10,
+                'value': 11,
+                'counter': 12,
+                'direction': 13,
+                }
+            }
+        }
+
+def to_file(filename, packet_list, mode='a', version=None):
     '''
     Save the given packets to the given file.
 
@@ -118,24 +205,36 @@ def to_file(filename, packet_list, mode='a', version='0.0'):
         ``TimestampPacket``.
     :param mode: optional, the "file mode" to open the data file
         (default: ``'a'``)
-    :param version: optional, the LArPix+HDF5 format version to use (for
-        backwards compatibility pick an earlier version) (default: '0.0')
+    :param version: optional, the LArPix+HDF5 format version to use. If
+        writing a new file and version is unspecified or ``None``,
+        the latest version will be used. If writing an existing file
+        and version is unspecified or ``None``, the existing file's
+        version will be used. If writing an existing file and version
+        is specified and does not exactly match the existing file's
+        version, a ``RuntimeError`` will be raised. (default: ``None``)
 
     '''
     with h5py.File(filename, mode) as f:
         # Create header
         if '_header' not in f.keys():
+            if version is None:
+                version = latest_version
             header = f.create_group('_header')
             header.attrs['version'] = version
             header.attrs['created'] = time.time()
         else:
             header = f['_header']
+            file_version = header.attrs['version']
+            if header.attrs['version'] != version:
+                raise RuntimeError('Incompatible versions: existing: %s, '
+                    'specified: %s' % (file_version, version))
         header.attrs['modified'] = time.time()
 
         # Create dataset
-        dtype = dtypes[version]['raw_packet']
-        if 'raw_packet' not in f.keys():
-            dset = f.create_dataset('raw_packet', shape=(len(packet_list),),
+        dset_name = next(iter(dtypes[version]))  # assumes only 1 dset
+        dtype = dtypes[version][dset_name]
+        if dset_name not in f.keys():
+            dset = f.create_dataset(dset_name, shape=(len(packet_list),),
                     maxshape=(None,), dtype=dtype)
             dset.attrs['packet_types'] = '''
 0: 'data',
@@ -146,7 +245,7 @@ def to_file(filename, packet_list, mode='a', version='0.0'):
 '''
             start_index = 0
         else:
-            dset = f['raw_packet']
+            dset = f[dset_name]
             start_index = dset.shape[0]
             dset.resize(start_index + len(packet_list), axis=0)
 
@@ -159,43 +258,73 @@ def to_file(filename, packet_list, mode='a', version='0.0'):
                     else dict_rep.get(key, 0) for key, val_type in dtype)))
         dset[start_index:] = encoded_packets
 
-def from_file(filename):
+def from_file(filename, version=None):
     '''
     Read the data from the given file into LArPix Packet objects.
 
     :param filename: the name of the file to read
+    :param version: the format version. Specify this parameter to
+        enforce a version check. When a specific version such as
+        ``'1.5'`` is specified, a ``RuntimeError`` will be raised if the
+        stored format version number is not an exact match. If a version
+        is prefixed with ``'~'`` such as ``'~1.5'``, a ``RuntimeError``
+        will be raised if the stored format version is *incompatible*
+        with the specified version. Compatible versions are those with
+        the same major version and at least the same minor version. E.g.
+        for ``'~1.5'``, versions between v1.5 and v2.0 are compatible.
+        If unspecified or ``None``, will use the stored format version.
     :returns packet_dict: a dict with keys ``'packets'`` containing a
         list of packet objects; and ``'created'``, ``'modified'``, and
         ``'version'``, containing the file metadata.
 
     '''
     with h5py.File(filename, 'r') as f:
-        if f['_header'].attrs['version'] != '0.0':
-            raise RuntimeError('Invalid version (should be 0.0): %s' %
-                    f['_header'].attrs['version'])
+        file_version = f['_header'].attrs['version']
+        if version is None:
+            version = file_version
+        elif version[0] == '~':
+            file_major, _, file_minor = file_version.split('.')
+            version_major, _, version_minor = version.split('.')
+            version_major = version_major[1:]
+            if (file_major != version_major
+                    or file_minor < version_minor):
+                raise RuntimeError('Incompatible versions: existing: %s, '
+                    'specified: %s' % (file_version, version))
+            else:
+                version = file_version
+        elif version == file_version:
+            pass
+        else:
+            raise RuntimeError('Incompatible versions: existing: %s, '
+                'specified: %s' % (file_version, version))
+        if version not in dtypes:
+            raise RuntimeError('Unknown version: %s' % version)
+        dset_name = next(iter(dtypes[version]))  # assumes only 1 dset
+        props = dtype_property_index_lookup[version][dset_name]
         packets = []
-        for row in f['raw_packet']:
+        for row in f[dset_name]:
             if row[1] == 4:
-                packets.append(TimestampPacket(row[6]))
+                packets.append(TimestampPacket(row[props['timestamp']]))
                 continue
             p = Packet()
-            p.chip_key = row[0]
-            p.packet_type = row[1]
-            p.chipid = row[2]
-            p.parity_bit_value = row[3]
+            p.chip_key = row[props['chip_key']]
+            p.packet_type = row[props['type']]
+            p.chipid = row[props['chipid']]
+            p.parity_bit_value = row[props['parity']]
             if p.packet_type == Packet.DATA_PACKET:
-                p.channel = row[5]
-                p.timestamp = row[6]
-                p.dataword = row[7]
-                p.fifo_half_flag = row[8]
-                p.fifo_full_flag = row[9]
+                p.channel = row[props['channel']]
+                p.timestamp = row[props['timestamp']]
+                p.dataword = row[props['adc_counts']]
+                p.fifo_half_flag = row[props['fifo_half']]
+                p.fifo_full_flag = row[props['fifo_full']]
             elif p.packet_type == Packet.TEST_PACKET:
-                p.counter = row[12]
+                p.counter = row[props['counter']]
             elif (p.packet_type == Packet.CONFIG_WRITE_PACKET
                     or p.packet_type == Packet.CONFIG_READ_PACKET):
-                p.register_address = row[10]
-                p.register_data = row[11]
-            p.direction = row[13]
+                p.register_address = row[props['register']]
+                p.register_data = row[props['value']]
+            if version != '0.0':
+                p.direction = row[props['direction']]
             packets.append(p)
         return {
                 'packets': packets,

--- a/larpix/io/fakeio.py
+++ b/larpix/io/fakeio.py
@@ -108,7 +108,7 @@ class FakeIO(IO):
         if isinstance(timestamps, int):
             timestamps = list(range(timestamps, timestamps+npositions))
         for position, timestamp in reversed(list(zip(positions, timestamps))):
-            packets.insert(position, TimestampPacket(timestamp=timestamp))
+            packets.insert(position, TimestampPacket(timestamp))
 
     def send(self, packets):
         '''

--- a/larpix/io/fakeio.py
+++ b/larpix/io/fakeio.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 from collections import deque
 
 from larpix.io import IO
+from larpix.larpix import TimestampPacket
 
 class FakeIO(IO):
     '''
@@ -80,6 +81,34 @@ class FakeIO(IO):
         if not 'chip_key' in kwargs:
             raise ValueError('FakeIO chip keys require an explicit chip_key')
         return kwargs['chip_key']
+
+    @staticmethod
+    def add_timestamps(packets, positions, timestamps=0):
+        '''
+        Insert timestamp packets into a list of packets in the given
+        positions.
+
+        Convenience method for modifying lists of packets to add to the
+        FakeIO queue. Modifies the list in-place.
+
+        The positions are with respect to the indexes of the original
+        list, so that the inserted element is just before the element
+        that originally had that index. e.g.
+
+        >>> add_timestamps([a, b, c, d], [1, 3])
+        [a, TimestampPacket(...), b, c, TimestampPacket(...), d]
+
+        If timestamps is a list, those timestamps will be used for the
+        TimestampPackets. If it is an int, it will be taken as the
+        starting time, and each subsequent packet will be incremented by
+        1. A default starting time of 0 is assumed.
+
+        '''
+        npositions = len(positions)
+        if isinstance(timestamps, int):
+            timestamps = list(range(timestamps, timestamps+npositions))
+        for position, timestamp in reversed(list(zip(positions, timestamps))):
+            packets.insert(position, TimestampPacket(timestamp=timestamp))
 
     def send(self, packets):
         '''

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -15,6 +15,7 @@ import struct
 from bitarray import bitarray
 
 from . import bitarrayhelper as bah
+from .logger import Logger
 from . import configs
 
 class Chip(object):
@@ -1071,7 +1072,7 @@ class Controller(object):
         else:
             warnings.warn('no IO object exists, no packets sent', RuntimeWarning)
         if self.logger:
-            self.logger.record(packets, direction=0)
+            self.logger.record(packets, direction=self.logger.WRITE)
 
     def start_listening(self):
         '''
@@ -1111,7 +1112,7 @@ class Controller(object):
         else:
             warnings.warn('no IO object exists, no packets will be received', RuntimeWarning)
         if self.logger:
-            self.logger.record(packets, direction=1)
+            self.logger.record(packets, direction=self.logger.READ)
         return packets, bytestream
 
     def write_configuration(self, chip_key, registers=None, write_read=0,
@@ -1778,7 +1779,7 @@ class Packet(object):
     def __str__(self):
         string = '[ '
         if hasattr(self, 'direction'):
-            string += {0: 'Out', 1: 'In'}[self.direction]
+            string += {Logger.WRITE: 'Out', Logger.READ: 'In'}[self.direction]
             string += ' | '
         string += 'Chip key: {} | '.format(self.chip_key)
         ptype = self.packet_type

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -1071,7 +1071,7 @@ class Controller(object):
         else:
             warnings.warn('no IO object exists, no packets sent', RuntimeWarning)
         if self.logger:
-            self.logger.record(packets, direction=0, timestamp=timestamp)
+            self.logger.record(packets, direction=0)
 
     def start_listening(self):
         '''
@@ -1111,7 +1111,7 @@ class Controller(object):
         else:
             warnings.warn('no IO object exists, no packets will be received', RuntimeWarning)
         if self.logger:
-            self.logger.record(packets, direction=1, timestamp=timestamp)
+            self.logger.record(packets, direction=1)
         return packets, bytestream
 
     def write_configuration(self, chip_key, registers=None, write_read=0,

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -1345,15 +1345,9 @@ class Controller(object):
         start_time = time.time()
         packets = []
         bytestreams = []
-        timestamp = TimestampPacket(timestamp=int(time.time()))
-        self.logger.record([timestamp], data_type='READ')
-        packets.append(timestamp)
         while time.time() - start_time < timelimit:
             time.sleep(sleeptime)
             read_packets, read_bytestream = self.read()
-            timestamp = TimestampPacket(timestamp=int(time.time()))
-            self.logger.record([timestamp], data_type='READ')
-            read_packets.append(timestamp)
             packets.extend(read_packets)
             bytestreams.append(read_bytestream)
         self.stop_listening()

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -1571,10 +1571,10 @@ class Controller(object):
                     separators=(',',':'), sort_keys=True)
 
 class TimestampPacket(object):
-    def __init__(self, timestamp_bytes=None, timestamp=None):
+    def __init__(self, timestamp=None, code=None):
         self.packet_type = 'timestamp'
-        if timestamp_bytes:
-            self.timestamp = struct.unpack('<Q', timestamp_bytes+b'\x00')[0]
+        if code:
+            self.timestamp = struct.unpack('<Q', code + b'\x00')[0]
         else:
             self.timestamp = timestamp
 

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -1611,7 +1611,7 @@ class TimestampPacket(object):
         return {
                 'type': 'timestamp',
                 'timestamp': self.timestamp,
-                'bits': self.bits,
+                'bits': self.bits.to01(),
                 }
 
     @property

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -1609,7 +1609,8 @@ class TimestampPacket(object):
 
     def export(self):
         return {
-                'type': 'timestamp',
+                'type_str': 'timestamp',
+                'type': self.packet_type,
                 'timestamp': self.timestamp,
                 'bits': self.bits.to01(),
                 }

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -1590,6 +1590,12 @@ class TimestampPacket(object):
     def __repr__(self):
         return 'TimestampPacket(%d)' % self.timestamp
 
+    def __eq__(self, other):
+        return self.timestamp == other.timestamp
+
+    def __ne__(self, other):
+        return not (self == other)
+
     def export(self):
         return {
                 'type': 'timestamp',

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -1578,6 +1578,7 @@ class Controller(object):
 
 class TimestampPacket(object):
     def __init__(self, timestamp_bytes=None, timestamp=None):
+        self.packet_type = 'timestamp'
         if timestamp_bytes:
             self.timestamp = struct.unpack('<Q', timestamp_bytes+b'\x00')[0]
         else:

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -1589,7 +1589,7 @@ class TimestampPacket(object):
     size = 56
     chip_key = None
     def __init__(self, timestamp=None, code=None):
-        self.packet_type = 'timestamp'
+        self.packet_type = 4
         if code:
             self.timestamp = struct.unpack('<Q', code + b'\x00')[0]
         else:
@@ -1777,7 +1777,8 @@ class Packet(object):
         d = {}
         d['chip_key'] = self.chip_key
         d['bits'] = self.bits.to01()
-        d['type'] = type_map[self.packet_type.to01()]
+        d['type_str'] = type_map[self.packet_type.to01()]
+        d['type'] = bah.touint(self.packet_type)
         d['chipid'] = self.chipid
         d['parity'] = self.parity_bit_value
         d['valid_parity'] = self.has_valid_parity()
@@ -2070,7 +2071,8 @@ class PacketCollection(object):
         - all packets:
              - chip_key
              - bits
-             - type (data, test, config read, config write)
+             - type_str (data, test, config read, config write)
+             - type (0, 1, 2, 3)
              - chipid
              - parity
              - valid_parity

--- a/larpix/logger/__init__.py
+++ b/larpix/logger/__init__.py
@@ -5,6 +5,12 @@ class Logger(object):
     into the larpix core.
 
     '''
+
+    #: Flag to indicate packets were sent to ASICs
+    WRITE = 0
+    #: Flag to indicate packets were received from ASICs
+    READ = 1
+
     def __init__(self, *args, **kwargs):
         '''
         Create new logger instance.
@@ -17,8 +23,9 @@ class Logger(object):
         Log specified data.
 
         :param data: ``list`` of data to be written to log. Valid data types are specified by logger implementation. Raises a ``ValueError`` if datatype is invalid.
-        :param direction: 0 if packets were sent to ASICs, 1 if packets
-            were received from ASICs. optional, default=0
+        :param direction: ``Logger.WRITE`` if packets were sent to
+            ASICs, ``Logger.READ`` if packets
+            were received from ASICs. (default: ``Logger.WRITE``)
 
         '''
         pass

--- a/larpix/logger/__init__.py
+++ b/larpix/logger/__init__.py
@@ -12,7 +12,7 @@ class Logger(object):
         '''
         pass
 
-    def record(self, data, direction=None, timestamp=None, *args, **kwargs):
+    def record(self, data, direction=None, *args, **kwargs):
         '''
         Log specified data.
 
@@ -20,7 +20,6 @@ class Logger(object):
         :param direction: optional, 0 if packets were sent to ASICs, 1 if packets
             were received from ASICs. If specified, will add a
             DirectionPacket to the logger.
-        :param timestamp: a unix timestamp to be associated with this log entry
 
         '''
         pass

--- a/larpix/logger/__init__.py
+++ b/larpix/logger/__init__.py
@@ -12,11 +12,14 @@ class Logger(object):
         '''
         pass
 
-    def record(self, data, timestamp=None, *args, **kwargs):
+    def record(self, data, direction=None, timestamp=None, *args, **kwargs):
         '''
         Log specified data.
 
         :param data: ``list`` of data to be written to log. Valid data types are specified by logger implementation. Raises a ``ValueError`` if datatype is invalid.
+        :param direction: optional, 0 if packets were sent to ASICs, 1 if packets
+            were received from ASICs. If specified, will add a
+            DirectionPacket to the logger.
         :param timestamp: a unix timestamp to be associated with this log entry
 
         '''

--- a/larpix/logger/__init__.py
+++ b/larpix/logger/__init__.py
@@ -12,14 +12,13 @@ class Logger(object):
         '''
         pass
 
-    def record(self, data, direction=None, *args, **kwargs):
+    def record(self, data, direction=0, *args, **kwargs):
         '''
         Log specified data.
 
         :param data: ``list`` of data to be written to log. Valid data types are specified by logger implementation. Raises a ``ValueError`` if datatype is invalid.
-        :param direction: optional, 0 if packets were sent to ASICs, 1 if packets
-            were received from ASICs. If specified, will add a
-            DirectionPacket to the logger.
+        :param direction: 0 if packets were sent to ASICs, 1 if packets
+            were received from ASICs. optional, default=0
 
         '''
         pass

--- a/larpix/logger/h5_logger.py
+++ b/larpix/logger/h5_logger.py
@@ -72,7 +72,7 @@ class HDF5Logger(Logger):
         log_postfix = '.h5'
         return (log_prefix + '_' + log_specifier + '_' + log_postfix)
 
-    def record(self, data, direction=None, timestamp=None, *args, **kwargs):
+    def record(self, data, direction=None):
         '''
         Send the specified data to log file
         .. note:: buffer is flushed after all ``data`` is placed in buffer, this
@@ -82,7 +82,7 @@ class HDF5Logger(Logger):
         :param direction: optional, 0 if packets were sent to ASICs, 1 if packets
             were received from ASICs. If specified, will add a
             DirectionPacket to the logger.
-        :param timestamp: unix timestamp to be associated with data
+
         '''
         if not self.is_enabled():
             return
@@ -90,8 +90,6 @@ class HDF5Logger(Logger):
             self.open()
         if not isinstance(data, list):
             raise ValueError('data must be a list')
-        if not timestamp:
-            timestamp = time.time()
 
         if direction is not None:
             direction_packet = DirectionPacket(direction)

--- a/larpix/logger/h5_logger.py
+++ b/larpix/logger/h5_logger.py
@@ -71,15 +71,16 @@ class HDF5Logger(Logger):
         log_postfix = '.h5'
         return (log_prefix + '_' + log_specifier + '_' + log_postfix)
 
-    def record(self, data, direction=0):
+    def record(self, data, direction=Logger.WRITE):
         '''
         Send the specified data to log file
         .. note:: buffer is flushed after all ``data`` is placed in buffer, this
             means that the buffer size will exceed the set value temporarily
 
         :param data: list of data to be written to log
-        :param direction: 0 if packets were sent to ASICs, 1 if packets
-            were received from ASICs. (default: 0)
+        :param direction: ``Logger.WRITE`` if packets were sent to
+            ASICs, ``Logger.READ`` if packets
+            were received from ASICs. (default: ``Logger.WRITE``)
 
         '''
         if not self.is_enabled():

--- a/larpix/logger/h5_logger.py
+++ b/larpix/logger/h5_logger.py
@@ -44,20 +44,19 @@ class HDF5Logger(Logger):
     }
     data_desc = {
         'raw_packet' : [
-            ('record_timestamp','f8'),
             ('chip_key','S32'),
-            ('type','i8'),
-            ('chipid','i8'),
-            ('parity','i1'),
-            ('valid_parity','i1'),
-            ('counter','i8'),
-            ('channel','i8'),
-            ('timestamp','i8'),
-            ('adc_counts','i8'),
-            ('fifo_half','i1'),
-            ('fifo_full','i1'),
-            ('register','i8'),
-            ('value','i8')
+            ('type','S12'),
+            ('chipid','u1'),
+            ('parity','u1'),
+            ('valid_parity','u1'),
+            ('counter','u4'),
+            ('channel','u1'),
+            ('timestamp','u8'),
+            ('adc_counts','u1'),
+            ('fifo_half','u1'),
+            ('fifo_full','u1'),
+            ('register','u1'),
+            ('value','u1')
         ]
     }
 
@@ -142,23 +141,9 @@ class HDF5Logger(Logger):
         if not isinstance(packet, Packet):
             raise ValueError('packet must be of type Packet')
         dict_rep = packet.export()
-        data_list = []
-        for key, dtype in cls.data_desc['raw_packet']:
-            if key == 'record_timestamp':
-                if timestamp:
-                    data_list += [timestamp]
-                else:
-                    data_list += [-1]
-            elif key == 'chip_key':
-                data_list += [str(dict_rep['chip_key'])]
-            elif key in dict_rep:
-                if key == 'type':
-                    data_list += [int(packet.packet_type.to01(), 2)]
-                else:
-                    data_list += [dict_rep[key]]
-            else:
-                data_list += [-1]
-        return np.array(tuple(data_list),dtype=cls.data_desc['raw_packet'])
+        data_list = tuple(dict_rep.get(key, 0) for key, _ in
+                cls.data_desc['raw_packet'])
+        return np.array(data_list, dtype=cls.data_desc['raw_packet'])
 
     def record(self, data, timestamp=None, *args, **kwargs):
         '''

--- a/larpix/logger/h5_logger.py
+++ b/larpix/logger/h5_logger.py
@@ -5,7 +5,7 @@ import numpy as np
 import h5py
 
 from larpix.logger import Logger
-from larpix.larpix import Packet, TimestampPacket, DirectionPacket
+from larpix.larpix import Packet, TimestampPacket
 from larpix.format.hdf5format import to_file, dtypes
 
 class HDF5Logger(Logger):
@@ -41,7 +41,6 @@ class HDF5Logger(Logger):
     data_desc_map = {
         Packet: 'raw_packet',
         TimestampPacket: 'raw_packet',
-        DirectionPacket: 'raw_packet',
     }
     dataset_list = list(dtypes[VERSION].keys())
 
@@ -72,16 +71,15 @@ class HDF5Logger(Logger):
         log_postfix = '.h5'
         return (log_prefix + '_' + log_specifier + '_' + log_postfix)
 
-    def record(self, data, direction=None):
+    def record(self, data, direction=0):
         '''
         Send the specified data to log file
         .. note:: buffer is flushed after all ``data`` is placed in buffer, this
             means that the buffer size will exceed the set value temporarily
 
         :param data: list of data to be written to log
-        :param direction: optional, 0 if packets were sent to ASICs, 1 if packets
-            were received from ASICs. If specified, will add a
-            DirectionPacket to the logger.
+        :param direction: 0 if packets were sent to ASICs, 1 if packets
+            were received from ASICs. (default: 0)
 
         '''
         if not self.is_enabled():
@@ -91,11 +89,8 @@ class HDF5Logger(Logger):
         if not isinstance(data, list):
             raise ValueError('data must be a list')
 
-        if direction is not None:
-            direction_packet = DirectionPacket(direction)
-            dataset = self.data_desc_map[type(direction_packet)]
-            self._buffer[dataset].append(direction_packet)
         for data_obj in data:
+            data_obj.direction = direction
             dataset = self.data_desc_map[type(data_obj)]
             self._buffer[dataset].append(data_obj)
 

--- a/larpix/logger/h5_logger.py
+++ b/larpix/logger/h5_logger.py
@@ -6,6 +6,7 @@ import h5py
 
 from larpix.logger import Logger
 from larpix.larpix import Packet, TimestampPacket
+from larpix.format.hdf5format import to_file, dtypes
 
 class HDF5Logger(Logger):
     '''
@@ -19,11 +20,10 @@ class HDF5Logger(Logger):
         The available fields are indicated in ``HDF5Logger.header_keys``. The header
         is initialized upon opening the logger.
 
-    *Datasets:* specified by ``HDF5Logger.data_desc`` and ``HDF5Logger.data_desc_map``
+    *Datasets:* specified by ``HDF5Logger.dataset_list`` and ``HDF5Logger.data_desc_map``
 
-        ``HDF5Logger.data_desc``: This describes the name of all datasets as
-        well as the data format. All datasets are stored as mixed-type arrays with
-        a data format indicated by the list ``HDF5Logger.data_desc[<dataset>]``.
+        ``HDF5Logger.dataset_list``: Lists the datasets that are
+        produced.
 
         ``HDF5Logger.data_desc_map``: This maps specifies the mapping between
         larpix core datatypes and the dataset within the HDF5 file. E.g.,
@@ -38,28 +38,11 @@ class HDF5Logger(Logger):
 
     '''
     VERSION = '0.0'
-    header_keys = ['version','created']
     data_desc_map = {
         Packet: 'raw_packet',
         TimestampPacket: 'raw_packet',
     }
-    data_desc = {
-        'raw_packet' : [
-            ('chip_key','S32'),
-            ('type','S12'),
-            ('chipid','u1'),
-            ('parity','u1'),
-            ('valid_parity','u1'),
-            ('counter','u4'),
-            ('channel','u1'),
-            ('timestamp','u8'),
-            ('adc_counts','u1'),
-            ('fifo_half','u1'),
-            ('fifo_full','u1'),
-            ('register','u1'),
-            ('value','u1')
-        ]
-    }
+    dataset_list = list(dtypes[VERSION].keys())
 
     def __init__(self, filename=None, buffer_length=10000,
             directory=''):
@@ -68,8 +51,8 @@ class HDF5Logger(Logger):
         self.datafile = None
         self.buffer_length = buffer_length
 
-        self._buffer = dict([(dataset, []) for dataset in self.data_desc.keys()])
-        self._write_idx = dict([(dataset, 0) for dataset in self.data_desc.keys()])
+        self._buffer = dict([(dataset, []) for dataset in
+            self.dataset_list])
         self._is_enabled = False
         self._is_open = False
 
@@ -87,61 +70,6 @@ class HDF5Logger(Logger):
             log_specifier = time.strftime(time_format, timestamp)
         log_postfix = '.h5'
         return (log_prefix + '_' + log_specifier + '_' + log_postfix)
-
-    def _create_header(self):
-        '''
-        Create datafile header
-
-        '''
-        if not self.is_open():
-            return
-        if '_header' in self.datafile.keys():
-            return
-        header = self.datafile.create_group('_header')
-        for header_key in self.header_keys:
-            if header_key == 'version':
-                header.attrs[header_key] = self.VERSION
-            elif header_key == 'created':
-                header.attrs[header_key] = time.time()
-
-    def _create_datasets(self):
-        '''
-        Create any missing datasets in file according to ``data_desc``
-
-        '''
-        if not self.is_open():
-            return
-        for dataset_name in self.data_desc.keys():
-            if not dataset_name in self.datafile.keys():
-                self.datafile.create_dataset(dataset_name, (0,), maxshape=(None,),
-                    dtype=self.data_desc[dataset_name])
-
-    @classmethod
-    def encode(cls, data, *args, **kwargs):
-        '''
-        Converts data object into a numpy mixed type array as described by
-        ``data_desc``. Raises a ``ValueError`` if the data object cannot be
-        encoded.
-
-        :returns: a ``numpy`` mixed-type array representing the data object
-
-        '''
-        if isinstance(data, (Packet, TimestampPacket)):
-            return cls.encode_packet(data, *args, **kwargs)
-        raise ValueError('h5_logger can only encode Packet objects')
-
-    @classmethod
-    def encode_packet(cls, packet, *args, **kwargs):
-        '''
-        Converts packets into numpy mixed typ array according to ``data_desc['raw_packet']``
-
-        :returns: a ``numpy`` mixed-type array representing the data object
-
-        '''
-        dict_rep = packet.export()
-        data_list = tuple(dict_rep.get(key, 0) for key, _ in
-                cls.data_desc['raw_packet'])
-        return np.array(data_list, dtype=cls.data_desc['raw_packet'])
 
     def record(self, data, timestamp=None, *args, **kwargs):
         '''
@@ -163,7 +91,7 @@ class HDF5Logger(Logger):
 
         for data_obj in data:
             dataset = self.data_desc_map[type(data_obj)]
-            self._buffer[dataset] += [self.encode(data_obj, timestamp=timestamp)]
+            self._buffer[dataset].append(data_obj)
 
         if any([len(buff) > self.buffer_length for dataset, buff in self._buffer.items()]):
             self.flush()
@@ -215,14 +143,9 @@ class HDF5Logger(Logger):
         if not self.filename:
             self.filename = self._default_filename()
         self.filename = os.path.join(self.directory, self.filename)
-        self.datafile = h5py.File(self.filename)
+        to_file(self.filename, [], version=self.VERSION)
         self._is_open = True
         self._is_enabled = enable
-
-        self._create_header()
-        self._create_datasets()
-        for dataset in self.data_desc.keys():
-            self._write_idx[dataset] = self.datafile[dataset].shape[0]
 
     def close(self):
         '''
@@ -233,7 +156,6 @@ class HDF5Logger(Logger):
         if not self.is_open():
             return
         self.flush()
-        self.datafile.close()
         self._is_open = False
         self._is_enabled = False
 
@@ -243,14 +165,6 @@ class HDF5Logger(Logger):
         '''
         if not self.is_open():
             return
-        for dataset in self.data_desc.keys():
-            if self._buffer[dataset]:
-                to_store = np.array(self._buffer[dataset])
-                new_entries = to_store.shape[0]
-                curr_idx = self._write_idx[dataset]
-                next_idx = curr_idx + new_entries
-                if next_idx >= self.datafile[dataset].shape[0]:
-                    self.datafile[dataset].resize(next_idx, axis=0)
-                self.datafile[dataset][curr_idx:next_idx] = to_store
-                self._buffer[dataset] = []
-                self._write_idx[dataset] = next_idx
+        to_file(self.filename, self._buffer['raw_packet'],
+                version=self.VERSION)
+        self._buffer['raw_packet'] = []

--- a/larpix/logger/h5_logger.py
+++ b/larpix/logger/h5_logger.py
@@ -5,7 +5,7 @@ import numpy as np
 import h5py
 
 from larpix.logger import Logger
-from larpix.larpix import Packet
+from larpix.larpix import Packet, TimestampPacket
 
 class HDF5Logger(Logger):
     '''
@@ -40,7 +40,8 @@ class HDF5Logger(Logger):
     VERSION = '0.0'
     header_keys = ['version','created']
     data_desc_map = {
-        Packet: 'raw_packet'
+        Packet: 'raw_packet',
+        TimestampPacket: 'raw_packet',
     }
     data_desc = {
         'raw_packet' : [
@@ -125,21 +126,18 @@ class HDF5Logger(Logger):
         :returns: a ``numpy`` mixed-type array representing the data object
 
         '''
-        if not isinstance(data, (Packet)):
-            raise ValueError('h5_logger can only encode Packet objects')
-        if isinstance(data, Packet):
+        if isinstance(data, (Packet, TimestampPacket)):
             return cls.encode_packet(data, *args, **kwargs)
+        raise ValueError('h5_logger can only encode Packet objects')
 
     @classmethod
-    def encode_packet(cls, packet, timestamp=None, *args, **kwargs):
+    def encode_packet(cls, packet, *args, **kwargs):
         '''
         Converts packets into numpy mixed typ array according to ``data_desc['raw_packet']``
 
         :returns: a ``numpy`` mixed-type array representing the data object
 
         '''
-        if not isinstance(packet, Packet):
-            raise ValueError('packet must be of type Packet')
         dict_rep = packet.export()
         data_list = tuple(dict_rep.get(key, 0) for key, _ in
                 cls.data_desc['raw_packet'])

--- a/larpix/logger/stdout_logger.py
+++ b/larpix/logger/stdout_logger.py
@@ -19,15 +19,15 @@ class StdoutLogger(Logger):
         self._is_open = False
         self.buffer_length = buffer_length
 
-    def record(self, data, direction=None, timestamp=None, *args, **kwargs):
+    def record(self, data, direction=None):
         '''
         Send the specified data to stdout
 
         :param data: list of data to be written to log
         :param direction: optional, 0 if packets were sent to ASICs, 1 if packets
             were received from ASICs. If specified, will add a
-            DirectionPacket to the logger.
-        :param timestamp: unix timestamp to be associated with data
+            ``DirectionPacket`` to the logger. If not (or if ``None``), no
+            ``DirectionPacket`` will be added.
         '''
         if not self._is_enabled:
             return
@@ -35,8 +35,6 @@ class StdoutLogger(Logger):
             self.open()
         if not isinstance(data,list):
             raise ValueError('data must be a list')
-        if not timestamp:
-            timestamp = time.time()
 
         if direction is not None:
             direction_packet = DirectionPacket(direction)

--- a/larpix/logger/stdout_logger.py
+++ b/larpix/logger/stdout_logger.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 import time
 
 from larpix.logger import Logger
-from larpix.larpix import Packet, DirectionPacket
+from larpix.larpix import Packet
 
 class StdoutLogger(Logger):
     '''
@@ -19,15 +19,13 @@ class StdoutLogger(Logger):
         self._is_open = False
         self.buffer_length = buffer_length
 
-    def record(self, data, direction=None):
+    def record(self, data, direction=0):
         '''
         Send the specified data to stdout
 
         :param data: list of data to be written to log
-        :param direction: optional, 0 if packets were sent to ASICs, 1 if packets
-            were received from ASICs. If specified, will add a
-            ``DirectionPacket`` to the logger. If not (or if ``None``), no
-            ``DirectionPacket`` will be added.
+        :param direction: 0 if packets were sent to ASICs, 1 if packets
+            were received from ASICs. optional, default=0
         '''
         if not self._is_enabled:
             return
@@ -35,11 +33,6 @@ class StdoutLogger(Logger):
             self.open()
         if not isinstance(data,list):
             raise ValueError('data must be a list')
-
-        if direction is not None:
-            direction_packet = DirectionPacket(direction)
-            self._buffer.append(['Record: '
-                '{}'.format(str(direction_packet))])
 
         self._buffer += ['Record: {}'.format(str(data_obj)) for data_obj in data]
 

--- a/larpix/logger/stdout_logger.py
+++ b/larpix/logger/stdout_logger.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 import time
 
 from larpix.logger import Logger
-from larpix.larpix import Packet
+from larpix.larpix import Packet, DirectionPacket
 
 class StdoutLogger(Logger):
     '''
@@ -19,11 +19,14 @@ class StdoutLogger(Logger):
         self._is_open = False
         self.buffer_length = buffer_length
 
-    def record(self, data, timestamp=None, *args, **kwargs):
+    def record(self, data, direction=None, timestamp=None, *args, **kwargs):
         '''
         Send the specified data to stdout
 
         :param data: list of data to be written to log
+        :param direction: optional, 0 if packets were sent to ASICs, 1 if packets
+            were received from ASICs. If specified, will add a
+            DirectionPacket to the logger.
         :param timestamp: unix timestamp to be associated with data
         '''
         if not self._is_enabled:
@@ -35,7 +38,12 @@ class StdoutLogger(Logger):
         if not timestamp:
             timestamp = time.time()
 
-        self._buffer += ['Record {}: {}'.format(timestamp, str(data_obj)) for data_obj in data]
+        if direction is not None:
+            direction_packet = DirectionPacket(direction)
+            self._buffer.append(['Record: '
+                '{}'.format(str(direction_packet))])
+
+        self._buffer += ['Record: {}'.format(str(data_obj)) for data_obj in data]
 
         if len(self._buffer) > self.buffer_length:
             self.flush()

--- a/test/test_h5_logger.py
+++ b/test/test_h5_logger.py
@@ -60,7 +60,7 @@ def test_record(tmpdir):
     logger = HDF5Logger(directory=str(tmpdir))
     logger.open()
 
-    logger.record([Packet()], timestamp=5.0)
+    logger.record([Packet()])
     assert len(logger._buffer['raw_packet']) == 1
     logger.record([TimestampPacket(timestamp=123)])
     assert len(logger._buffer['raw_packet']) == 2

--- a/test/test_h5_logger.py
+++ b/test/test_h5_logger.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 import pytest
 import os
 import numpy as np
-from larpix.larpix import Packet, Controller, Chip
+from larpix.larpix import Packet, Controller, Chip, TimestampPacket
 from larpix.io.fakeio import FakeIO
 from larpix.logger.h5_logger import HDF5Logger
 
@@ -57,11 +57,13 @@ def test_close(tmpdir):
     assert not logger.is_open()
 
 def test_record(tmpdir):
-    logger = HDF5Logger(directory=str(tmpdir), buffer_length=1)
+    logger = HDF5Logger(directory=str(tmpdir))
     logger.open()
 
     logger.record([Packet()], timestamp=5.0)
-    assert logger._buffer['raw_packet'][0] == HDF5Logger.encode(Packet(), timestamp=5.0)
+    assert len(logger._buffer['raw_packet']) == 1
+    logger.record([TimestampPacket(timestamp=123)])
+    assert len(logger._buffer['raw_packet']) == 2
 
 @pytest.mark.filterwarnings("ignore:no IO object")
 def test_controller_write_capture(tmpdir):

--- a/test/test_hdf5format.py
+++ b/test/test_hdf5format.py
@@ -4,7 +4,8 @@ import pytest
 import h5py
 
 from larpix.larpix import (Packet, PacketCollection, TimestampPacket)
-from larpix.format.hdf5format import to_file, from_file
+from larpix.format.hdf5format import (to_file, from_file,
+        dtype_property_index_lookup)
 
 @pytest.fixture
 def tmpfile(tmpdir):
@@ -21,6 +22,7 @@ def data_packet():
     p.fifo_half_flag = 1
     p.assign_parity()
     p.chip_key = 'hello'
+    p.direction = 1
     return p
 
 @pytest.fixture
@@ -32,14 +34,16 @@ def config_read_packet():
     p.register_data = 23
     p.assign_parity()
     p.chip_key = 'hello'
+    p.direction = 1
     return p
 
 @pytest.fixture
 def timestamp_packet():
-    return TimestampPacket(timestamp=12345)
+    p = TimestampPacket(timestamp=12345)
+    return p
 
-def test_to_file_empty(tmpfile):
-    to_file(tmpfile, [])
+def test_to_file_v0_0_empty(tmpfile):
+    to_file(tmpfile, [], version='0.0')
     f = h5py.File(tmpfile, 'r')
     assert f['_header']
     assert f['_header'].attrs['version']
@@ -47,57 +51,136 @@ def test_to_file_empty(tmpfile):
     assert f['_header'].attrs['modified']
     assert f['raw_packet']
 
-def test_to_file_data_packet(tmpfile, data_packet):
-    to_file(tmpfile, [data_packet])
+def test_to_file_v0_0_data_packet(tmpfile, data_packet):
+    to_file(tmpfile, [data_packet], version='0.0')
     f = h5py.File(tmpfile, 'r')
     assert len(f['raw_packet']) == 1
     row = f['raw_packet'][0]
+    props = dtype_property_index_lookup['0.0']['raw_packet']
     new_packet = Packet()
-    new_packet.chip_key = row[0]
-    new_packet.packet_type = row[1]
-    new_packet.chipid = row[2]
-    new_packet.parity_bit_value = row[3]
-    new_packet.channel = row[5]
-    new_packet.timestamp = row[6]
-    new_packet.dataword = row[7]
-    new_packet.fifo_half_flag = row[8]
-    new_packet.fifo_full_flag = row[9]
+    new_packet.chip_key = row[props['chip_key']]
+    new_packet.packet_type = row[props['type']]
+    new_packet.chipid = row[props['chipid']]
+    new_packet.parity_bit_value = row[props['parity']]
+    new_packet.channel = row[props['channel']]
+    new_packet.timestamp = row[props['timestamp']]
+    new_packet.dataword = row[props['adc_counts']]
+    new_packet.fifo_half_flag = row[props['fifo_half']]
+    new_packet.fifo_full_flag = row[props['fifo_full']]
     assert new_packet == data_packet
 
-def test_to_file_config_read_packet(tmpfile, config_read_packet):
-    to_file(tmpfile, [config_read_packet])
+def test_to_file_v0_0_config_read_packet(tmpfile, config_read_packet):
+    to_file(tmpfile, [config_read_packet], version='0.0')
     f = h5py.File(tmpfile, 'r')
     assert len(f['raw_packet']) == 1
     row = f['raw_packet'][0]
+    props = dtype_property_index_lookup['0.0']['raw_packet']
     new_packet = Packet()
-    new_packet.chip_key = row[0]
-    new_packet.packet_type = row[1]
-    new_packet.chipid = row[2]
-    new_packet.parity_bit_value = row[3]
-    new_packet.register_address = row[10]
-    new_packet.register_data = row[11]
+    new_packet.chip_key = row[props['chip_key']]
+    new_packet.packet_type = row[props['type']]
+    new_packet.chipid = row[props['chipid']]
+    new_packet.parity_bit_value = row[props['parity']]
+    new_packet.register_address = row[props['register']]
+    new_packet.register_data = row[props['value']]
     assert new_packet == config_read_packet
 
-def test_to_file_timestamp_packet(tmpfile, timestamp_packet):
-    to_file(tmpfile, [timestamp_packet])
+def test_to_file_v0_0_timestamp_packet(tmpfile, timestamp_packet):
+    to_file(tmpfile, [timestamp_packet], version='0.0')
     f = h5py.File(tmpfile, 'r')
     assert len(f['raw_packet']) == 1
     row = f['raw_packet'][0]
-    assert row[1] == 4  # packet_type
+    props = dtype_property_index_lookup['0.0']['raw_packet']
+    assert row[props['type']] == 4  # packet_type
     new_packet = TimestampPacket()
-    new_packet.timestamp = row[6]
+    new_packet.timestamp = row[props['timestamp']]
     assert new_packet == timestamp_packet
 
-def test_to_file_many_packets(tmpfile, data_packet, config_read_packet,
+def test_to_file_v0_0_many_packets(tmpfile, data_packet, config_read_packet,
         timestamp_packet):
-    to_file(tmpfile, [data_packet, config_read_packet, timestamp_packet])
+    to_file(tmpfile, [data_packet, config_read_packet,
+        timestamp_packet], version='0.0')
     f = h5py.File(tmpfile, 'r')
     assert len(f['raw_packet']) == 3
 
-def test_from_file_many_packets(tmpfile, data_packet,
+def test_from_file_v0_0_many_packets(tmpfile, data_packet,
         config_read_packet, timestamp_packet):
     packets = [data_packet, config_read_packet, timestamp_packet]
-    to_file(tmpfile, packets)
+    to_file(tmpfile, packets, version='0.0')
+    new_packets_dict = from_file(tmpfile, version='0.0')
+    assert new_packets_dict['created']
+    assert new_packets_dict['version']
+    assert new_packets_dict['modified']
+    new_packets = new_packets_dict['packets']
+    assert new_packets[0] == data_packet
+    assert new_packets[1] == config_read_packet
+    assert new_packets[2] == timestamp_packet
+
+def test_to_file_v1_0_empty(tmpfile):
+    to_file(tmpfile, [], version='1.0')
+    f = h5py.File(tmpfile, 'r')
+    assert f['_header']
+    assert f['_header'].attrs['version']
+    assert f['_header'].attrs['created']
+    assert f['_header'].attrs['modified']
+    assert f['packets']
+
+def test_to_file_v1_0_data_packet(tmpfile, data_packet):
+    to_file(tmpfile, [data_packet], version='1.0')
+    f = h5py.File(tmpfile, 'r')
+    assert len(f['packets']) == 1
+    row = f['packets'][0]
+    props = dtype_property_index_lookup['1.0']['packets']
+    new_packet = Packet()
+    new_packet.chip_key = row[props['chip_key']]
+    new_packet.packet_type = row[props['type']]
+    new_packet.chipid = row[props['chipid']]
+    new_packet.parity_bit_value = row[props['parity']]
+    new_packet.channel = row[props['channel']]
+    new_packet.timestamp = row[props['timestamp']]
+    new_packet.dataword = row[props['adc_counts']]
+    new_packet.fifo_half_flag = row[props['fifo_half']]
+    new_packet.fifo_full_flag = row[props['fifo_full']]
+    new_packet.direction = row[props['direction']]
+    assert new_packet == data_packet
+
+def test_to_file_v1_0_config_read_packet(tmpfile, config_read_packet):
+    to_file(tmpfile, [config_read_packet], version='1.0')
+    f = h5py.File(tmpfile, 'r')
+    assert len(f['packets']) == 1
+    row = f['packets'][0]
+    props = dtype_property_index_lookup['1.0']['packets']
+    new_packet = Packet()
+    new_packet.chip_key = row[props['chip_key']]
+    new_packet.packet_type = row[props['type']]
+    new_packet.chipid = row[props['chipid']]
+    new_packet.parity_bit_value = row[props['parity']]
+    new_packet.register_address = row[props['register']]
+    new_packet.register_data = row[props['value']]
+    new_packet.direction = row[props['direction']]
+    assert new_packet == config_read_packet
+
+def test_to_file_v1_0_timestamp_packet(tmpfile, timestamp_packet):
+    to_file(tmpfile, [timestamp_packet], version='1.0')
+    f = h5py.File(tmpfile, 'r')
+    assert len(f['packets']) == 1
+    row = f['packets'][0]
+    props = dtype_property_index_lookup['1.0']['packets']
+    assert row[1] == 4  # packet_type
+    new_packet = TimestampPacket()
+    new_packet.timestamp = row[props['timestamp']]
+    assert new_packet == timestamp_packet
+
+def test_to_file_v1_0_many_packets(tmpfile, data_packet, config_read_packet,
+        timestamp_packet):
+    to_file(tmpfile, [data_packet, config_read_packet,
+        timestamp_packet], version='1.0')
+    f = h5py.File(tmpfile, 'r')
+    assert len(f['packets']) == 3
+
+def test_from_file_v1_0_many_packets(tmpfile, data_packet,
+        config_read_packet, timestamp_packet):
+    packets = [data_packet, config_read_packet, timestamp_packet]
+    to_file(tmpfile, packets, version='1.0')
     new_packets_dict = from_file(tmpfile)
     assert new_packets_dict['created']
     assert new_packets_dict['version']
@@ -106,3 +189,9 @@ def test_from_file_many_packets(tmpfile, data_packet,
     assert new_packets[0] == data_packet
     assert new_packets[1] == config_read_packet
     assert new_packets[2] == timestamp_packet
+
+def test_from_file_incompatible(tmpfile):
+    to_file(tmpfile, [], version='0.0')
+    with pytest.raises(RuntimeError):
+        from_file(tmpfile, version='1.0')
+        pytest.fail('Should identify incompatible version')

--- a/test/test_hdf5format.py
+++ b/test/test_hdf5format.py
@@ -3,8 +3,7 @@ from __future__ import print_function
 import pytest
 import h5py
 
-from larpix.larpix import (Packet, PacketCollection, TimestampPacket,
-        DirectionPacket)
+from larpix.larpix import (Packet, PacketCollection, TimestampPacket)
 from larpix.format.hdf5format import to_file, from_file
 
 @pytest.fixture
@@ -38,10 +37,6 @@ def config_read_packet():
 @pytest.fixture
 def timestamp_packet():
     return TimestampPacket(timestamp=12345)
-
-@pytest.fixture
-def direction_packet():
-    return DirectionPacket(direction=1)
 
 def test_to_file_empty(tmpfile):
     to_file(tmpfile, [])
@@ -93,27 +88,15 @@ def test_to_file_timestamp_packet(tmpfile, timestamp_packet):
     new_packet.timestamp = row[6]
     assert new_packet == timestamp_packet
 
-def test_to_file_direction_packet(tmpfile, direction_packet):
-    to_file(tmpfile, [direction_packet])
-    f = h5py.File(tmpfile, 'r')
-    assert len(f['raw_packet']) == 1
-    row = f['raw_packet'][0]
-    assert row[1] == 5  # packet_type
-    new_packet = DirectionPacket()
-    new_packet.direction = row[13]
-    assert new_packet == direction_packet
-
 def test_to_file_many_packets(tmpfile, data_packet, config_read_packet,
-        timestamp_packet, direction_packet):
-    to_file(tmpfile, [data_packet, config_read_packet, timestamp_packet,
-        direction_packet])
+        timestamp_packet):
+    to_file(tmpfile, [data_packet, config_read_packet, timestamp_packet])
     f = h5py.File(tmpfile, 'r')
-    assert len(f['raw_packet']) == 4
+    assert len(f['raw_packet']) == 3
 
 def test_from_file_many_packets(tmpfile, data_packet,
-        config_read_packet, timestamp_packet, direction_packet):
-    packets = [data_packet, config_read_packet, timestamp_packet,
-            direction_packet]
+        config_read_packet, timestamp_packet):
+    packets = [data_packet, config_read_packet, timestamp_packet]
     to_file(tmpfile, packets)
     new_packets_dict = from_file(tmpfile)
     assert new_packets_dict['created']
@@ -123,4 +106,3 @@ def test_from_file_many_packets(tmpfile, data_packet,
     assert new_packets[0] == data_packet
     assert new_packets[1] == config_read_packet
     assert new_packets[2] == timestamp_packet
-    assert new_packets[3] == direction_packet

--- a/test/test_hdf5format.py
+++ b/test/test_hdf5format.py
@@ -1,0 +1,126 @@
+from __future__ import print_function
+
+import pytest
+import h5py
+
+from larpix.larpix import (Packet, PacketCollection, TimestampPacket,
+        DirectionPacket)
+from larpix.format.hdf5format import to_file, from_file
+
+@pytest.fixture
+def tmpfile(tmpdir):
+    return str(tmpdir.join('test.h5'))
+
+@pytest.fixture
+def data_packet():
+    p = Packet()
+    p.packet_type = Packet.DATA_PACKET
+    p.chipid = 123
+    p.channel = 7
+    p.timestamp = 123456
+    p.dataword = 120
+    p.fifo_half_flag = 1
+    p.assign_parity()
+    p.chip_key = 'hello'
+    return p
+
+@pytest.fixture
+def config_read_packet():
+    p = Packet()
+    p.packet_type = Packet.CONFIG_READ_PACKET
+    p.chipid = 123
+    p.register_address = 10
+    p.register_data = 23
+    p.assign_parity()
+    p.chip_key = 'hello'
+    return p
+
+@pytest.fixture
+def timestamp_packet():
+    return TimestampPacket(timestamp=12345)
+
+@pytest.fixture
+def direction_packet():
+    return DirectionPacket(direction=1)
+
+def test_to_file_empty(tmpfile):
+    to_file(tmpfile, [])
+    f = h5py.File(tmpfile, 'r')
+    assert f['_header']
+    assert f['_header'].attrs['version']
+    assert f['_header'].attrs['created']
+    assert f['_header'].attrs['modified']
+    assert f['raw_packet']
+
+def test_to_file_data_packet(tmpfile, data_packet):
+    to_file(tmpfile, [data_packet])
+    f = h5py.File(tmpfile, 'r')
+    assert len(f['raw_packet']) == 1
+    row = f['raw_packet'][0]
+    new_packet = Packet()
+    new_packet.chip_key = row[0]
+    new_packet.packet_type = row[1]
+    new_packet.chipid = row[2]
+    new_packet.parity_bit_value = row[3]
+    new_packet.channel = row[5]
+    new_packet.timestamp = row[6]
+    new_packet.dataword = row[7]
+    new_packet.fifo_half_flag = row[8]
+    new_packet.fifo_full_flag = row[9]
+    assert new_packet == data_packet
+
+def test_to_file_config_read_packet(tmpfile, config_read_packet):
+    to_file(tmpfile, [config_read_packet])
+    f = h5py.File(tmpfile, 'r')
+    assert len(f['raw_packet']) == 1
+    row = f['raw_packet'][0]
+    new_packet = Packet()
+    new_packet.chip_key = row[0]
+    new_packet.packet_type = row[1]
+    new_packet.chipid = row[2]
+    new_packet.parity_bit_value = row[3]
+    new_packet.register_address = row[10]
+    new_packet.register_data = row[11]
+    assert new_packet == config_read_packet
+
+def test_to_file_timestamp_packet(tmpfile, timestamp_packet):
+    to_file(tmpfile, [timestamp_packet])
+    f = h5py.File(tmpfile, 'r')
+    assert len(f['raw_packet']) == 1
+    row = f['raw_packet'][0]
+    assert row[1] == 4  # packet_type
+    new_packet = TimestampPacket()
+    new_packet.timestamp = row[6]
+    assert new_packet == timestamp_packet
+
+def test_to_file_direction_packet(tmpfile, direction_packet):
+    to_file(tmpfile, [direction_packet])
+    f = h5py.File(tmpfile, 'r')
+    assert len(f['raw_packet']) == 1
+    row = f['raw_packet'][0]
+    assert row[1] == 5  # packet_type
+    new_packet = DirectionPacket()
+    new_packet.direction = row[13]
+    assert new_packet == direction_packet
+
+def test_to_file_many_packets(tmpfile, data_packet, config_read_packet,
+        timestamp_packet, direction_packet):
+    to_file(tmpfile, [data_packet, config_read_packet, timestamp_packet,
+        direction_packet])
+    f = h5py.File(tmpfile, 'r')
+    assert len(f['raw_packet']) == 4
+
+def test_from_file_many_packets(tmpfile, data_packet,
+        config_read_packet, timestamp_packet, direction_packet):
+    packets = [data_packet, config_read_packet, timestamp_packet,
+            direction_packet]
+    to_file(tmpfile, packets)
+    new_packets_dict = from_file(tmpfile)
+    assert new_packets_dict['created']
+    assert new_packets_dict['version']
+    assert new_packets_dict['modified']
+    new_packets = new_packets_dict['packets']
+    assert new_packets[0] == data_packet
+    assert new_packets[1] == config_read_packet
+    assert new_packets[2] == timestamp_packet
+    assert new_packets[3] == direction_packet

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -5,7 +5,7 @@ Use the pytest framework to write tests for the larpix module.
 from __future__ import print_function
 import pytest
 from larpix.larpix import (Chip, Packet, Configuration, Controller,
-        PacketCollection, _Smart_List)
+        PacketCollection, _Smart_List, TimestampPacket)
 from larpix.io.fakeio import FakeIO
 from larpix.timestamp import *  # use long = int in py3
 #from bitstring import BitArray
@@ -1774,6 +1774,12 @@ def test_packetcollection_getitem_int_bits():
     result = collection[0, 'bits']
     expected = ' '.join(packet.bits.to01()[i:i+8] for i in range(0, Packet.size, 8))
     assert result == expected
+    packet2 = TimestampPacket(123)
+    collection2 = PacketCollection([packet2])
+    result2 = collection2[0, 'bits']
+    expected2 = ' '.join(packet2.bits.to01()[i:i+8] for i in range(0,
+        packet2.size, 8))
+    assert result2 == expected2
 
 def test_packetcollection_getitem_slice():
     chip = Chip(0, 0)

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -79,7 +79,8 @@ def test_chip_export_reads():
             'packets': [
                 {
                     'bits': packet.bits.to01(),
-                    'type': 'config write',
+                    'type_str': 'config write',
+                    'type': 2,
                     'chipid': 1,
                     'chip_key': 2,
                     'parity': 1,
@@ -120,7 +121,8 @@ def test_chip_export_reads_all():
             'packets': [
                 {
                     'bits': packet.bits.to01(),
-                    'type': 'config write',
+                    'type_str': 'config write',
+                    'type': 2,
                     'chipid': 0,
                     'parity': 0,
                     'chip_key': 2,
@@ -209,7 +211,8 @@ def test_packet_export_test():
     result = p.export()
     expected = {
             'bits': p.bits.to01(),
-            'type': 'test',
+            'type_str': 'test',
+            'type': 1,
             'chipid': 5,
             'chip_key': None,
             'counter': 32838,
@@ -232,7 +235,8 @@ def test_packet_export_data():
     result = p.export()
     expected = {
             'bits': p.bits.to01(),
-            'type': 'data',
+            'type_str': 'data',
+            'type': 0,
             'chipid': 2,
             'chip_key': 1,
             'channel': 10,
@@ -256,7 +260,8 @@ def test_packet_export_config_read():
     result = p.export()
     expected = {
             'bits': p.bits.to01(),
-            'type': 'config read',
+            'type_str': 'config read',
+            'type': 3,
             'chipid': 10,
             'chip_key': 'test-key',
             'register': 51,
@@ -276,7 +281,8 @@ def test_packet_export_config_write():
     result = p.export()
     expected = {
             'bits': p.bits.to01(),
-            'type': 'config write',
+            'type_str': 'config write',
+            'type': 2,
             'chipid': 10,
             'chip_key': None,
             'register': 51,
@@ -1830,7 +1836,7 @@ def test_packetcollection_extract():
     expected = [36]
     assert pc.extract('adc_counts', chipid=10) == expected
     expected = [0]
-    assert pc.extract('counter', type='test') == expected
+    assert pc.extract('counter', type_str='test') == expected
 
 def test_packetcollection_to_dict():
     packet = Packet()
@@ -1847,7 +1853,8 @@ def test_packetcollection_to_dict():
             'bytestream': packet.bytes().decode('raw_unicode_escape'),
             'packets': [{
                 'bits': packet.bits.to01(),
-                'type': 'test',
+                'type_str': 'test',
+                'type': 1,
                 'chip_key': None,
                 'chipid': packet.chipid,
                 'parity': 0,

--- a/test/test_stdout_logger.py
+++ b/test/test_stdout_logger.py
@@ -70,7 +70,7 @@ def test_controller_write_capture(capfd):
     chip = controller.chips[0]
     controller.write_configuration(0, 0)
     packet = chip.get_configuration_packets(Packet.CONFIG_WRITE_PACKET)[0]
-    assert len(controller.logger._buffer) == 2
+    assert len(controller.logger._buffer) == 1
 
 def test_controller_read_capture(capfd):
     controller = Controller()
@@ -79,4 +79,4 @@ def test_controller_read_capture(capfd):
     controller.logger = StdoutLogger(buffer_length=100)
     controller.logger.open()
     controller.run(0.1,'test')
-    assert len(controller.logger._buffer) == 2
+    assert len(controller.logger._buffer) == 1

--- a/test/test_stdout_logger.py
+++ b/test/test_stdout_logger.py
@@ -59,24 +59,24 @@ def test_record():
     logger.open()
 
     logger.record(['test'], timestamp=5.0)
-    assert logger._buffer[0] == 'Record 5.0: test'
+    assert logger._buffer[0] == 'Record: test'
 
 @pytest.mark.filterwarnings("ignore:no IO object")
 def test_controller_write_capture(capfd):
     controller = Controller()
-    controller.logger = StdoutLogger(buffer_length=1)
+    controller.logger = StdoutLogger(buffer_length=100)
     controller.logger.open()
     controller.chips[0] = Chip(2, 0)
     chip = controller.chips[0]
     controller.write_configuration(0, 0)
     packet = chip.get_configuration_packets(Packet.CONFIG_WRITE_PACKET)[0]
-    assert len(controller.logger._buffer) == 1
+    assert len(controller.logger._buffer) == 2
 
 def test_controller_read_capture(capfd):
     controller = Controller()
     controller.io = FakeIO()
     controller.io.queue.append(([Packet()], b'\x00\x00'))
-    controller.logger = StdoutLogger(buffer_length=1)
+    controller.logger = StdoutLogger(buffer_length=100)
     controller.logger.open()
     controller.run(0.1,'test')
-    assert len(controller.logger._buffer) == 1
+    assert len(controller.logger._buffer) == 2

--- a/test/test_stdout_logger.py
+++ b/test/test_stdout_logger.py
@@ -58,7 +58,7 @@ def test_record():
     logger = StdoutLogger(buffer_length=1)
     logger.open()
 
-    logger.record(['test'], timestamp=5.0)
+    logger.record(['test'])
     assert logger._buffer[0] == 'Record: test'
 
 @pytest.mark.filterwarnings("ignore:no IO object")


### PR DESCRIPTION
I made a module that can convert between a list of packets and an HDF5 file. The format I used is slightly different from the HDF5Logger format so I updated the HDF5Logger to match. I have checked compatibility with some example data runs.

The major change here is in handling the "global timestamp" or "record timestamp" (formerly known as "serial timestamp"). Based on Dan's comments, special timestamp packets will be inserted into the data stream. They will be saved inline with the UART packets in the HDF5 file. For now, the timestamp packets are generated in the ``Controller.run`` method (or must be generated manually in programs that manually call ``Controller.read``). Eventually they will be part of the data stream that is received by the Controller's IO object.

I was torn on whether to modify the Packet object to add a new type, whether to inherit from Packet or a new common ancestor, or whether to just make a new type that implements similar methods to Packet. I decided on the latter because the TimestampPacket objects are so simple. This does mean that, when lists of packets are being processed, they will need to be filtered; however, that is already the case since the list of packets will contain config and data packets all in one list.

Please comment on this proposal/implementation.

#113 #112 