### PR TITLE
Add directory param to HDF5Logger init

### DIFF
--- a/larpix/logger/h5_logger.py
+++ b/larpix/logger/h5_logger.py
@@ -1,4 +1,6 @@
 import time
+import os
+
 import numpy as np
 import h5py
 
@@ -27,9 +29,12 @@ class HDF5Logger(Logger):
         larpix core datatypes and the dataset within the HDF5 file. E.g.,
         ``larpix.Packet`` objects are stored in ``'raw_packet'``.
 
-    :param filename: filename to store data (optional, default: ``None``)
+    :param filename: filename to store data (appended to ``directory``)
+        (optional, default: ``None``)
     :param buffer_length: how many data messages to hang on to before flushing
         buffer to the file (optional, default: ``10000``)
+    :param directory: the directory to save the data in (optional,
+        default: '')
 
     '''
     VERSION = '0.0'
@@ -56,8 +61,10 @@ class HDF5Logger(Logger):
         ]
     }
 
-    def __init__(self, filename=None, buffer_length=10000):
+    def __init__(self, filename=None, buffer_length=10000,
+            directory=''):
         self.filename = filename
+        self.directory = directory
         self.datafile = None
         self.buffer_length = buffer_length
 
@@ -224,6 +231,7 @@ class HDF5Logger(Logger):
             return
         if not self.filename:
             self.filename = self._default_filename()
+        self.filename = os.path.join(self.directory, self.filename)
         self.datafile = h5py.File(self.filename)
         self._is_open = True
         self._is_enabled = enable

--- a/test/test_h5_logger.py
+++ b/test/test_h5_logger.py
@@ -10,23 +10,8 @@ from larpix.larpix import Packet, Controller, Chip
 from larpix.io.fakeio import FakeIO
 from larpix.logger.h5_logger import HDF5Logger
 
-test_filename = '.test.h5'
-def fresh_temp_file(func):
-    def new_func(*args,**kwargs):
-        try:
-            os.remove(test_filename)
-        except:
-            pass
-        return_value = func(*args, **kwargs)
-        try:
-            os.remove(test_filename)
-        except:
-            pass
-    return new_func
-
-@fresh_temp_file
-def test_enable():
-    logger = HDF5Logger(filename=test_filename,buffer_length=1)
+def test_enable(tmpdir):
+    logger = HDF5Logger(directory=tmpdir,buffer_length=1)
     logger.open()
 
     logger.enable()
@@ -34,9 +19,8 @@ def test_enable():
     logger.record([Packet()])
     assert len(logger._buffer['raw_packet']) == 1
 
-@fresh_temp_file
-def test_disable():
-    logger = HDF5Logger(filename=test_filename)
+def test_disable(tmpdir):
+    logger = HDF5Logger(directory=tmpdir)
     logger.open()
 
     logger.disable()
@@ -44,17 +28,15 @@ def test_disable():
     logger.record([Packet()])
     assert len(logger._buffer['raw_packet']) == 0
 
-@fresh_temp_file
-def test_open():
-    logger = HDF5Logger(filename=test_filename)
+def test_open(tmpdir):
+    logger = HDF5Logger(directory=tmpdir)
     logger.open()
 
     assert logger.is_enabled()
     assert logger.is_open()
 
-@fresh_temp_file
-def test_flush():
-    logger = HDF5Logger(filename=test_filename, buffer_length=5)
+def test_flush(tmpdir):
+    logger = HDF5Logger(directory=tmpdir, buffer_length=5)
     logger.open()
 
     logger.record([Packet()])
@@ -66,28 +48,25 @@ def test_flush():
     logger.record([Packet()])
     assert len(logger._buffer['raw_packet']) == 0
 
-@fresh_temp_file
-def test_close():
-    logger = HDF5Logger(filename=test_filename)
+def test_close(tmpdir):
+    logger = HDF5Logger(directory=tmpdir)
     logger.open()
 
     logger.close()
     assert not logger.is_enabled()
     assert not logger.is_open()
 
-@fresh_temp_file
-def test_record():
-    logger = HDF5Logger(filename=test_filename, buffer_length=1)
+def test_record(tmpdir):
+    logger = HDF5Logger(directory=tmpdir, buffer_length=1)
     logger.open()
 
     logger.record([Packet()], timestamp=5.0)
     assert logger._buffer['raw_packet'][0] == HDF5Logger.encode(Packet(), timestamp=5.0)
 
 @pytest.mark.filterwarnings("ignore:no IO object")
-@fresh_temp_file
-def test_controller_write_capture():
+def test_controller_write_capture(tmpdir):
     controller = Controller()
-    controller.logger = HDF5Logger(filename=test_filename, buffer_length=1)
+    controller.logger = HDF5Logger(directory=tmpdir, buffer_length=1)
     controller.logger.open()
     controller.chips[0] = Chip(2, 0)
     chip = controller.chips[0]
@@ -95,12 +74,11 @@ def test_controller_write_capture():
     packet = chip.get_configuration_packets(Packet.CONFIG_WRITE_PACKET)[0]
     assert len(controller.logger._buffer) == 1
 
-@fresh_temp_file
-def test_controller_read_capture():
+def test_controller_read_capture(tmpdir):
     controller = Controller()
     controller.io = FakeIO()
     controller.io.queue.append(([Packet()], b'\x00\x00'))
-    controller.logger = HDF5Logger(filename=test_filename, buffer_length=1)
+    controller.logger = HDF5Logger(directory=tmpdir, buffer_length=1)
     controller.logger.open()
     controller.run(0.1,'test')
     assert len(controller.logger._buffer) == 1

--- a/test/test_h5_logger.py
+++ b/test/test_h5_logger.py
@@ -11,7 +11,7 @@ from larpix.io.fakeio import FakeIO
 from larpix.logger.h5_logger import HDF5Logger
 
 def test_enable(tmpdir):
-    logger = HDF5Logger(directory=tmpdir,buffer_length=1)
+    logger = HDF5Logger(directory=str(tmpdir),buffer_length=1)
     logger.open()
 
     logger.enable()
@@ -20,7 +20,7 @@ def test_enable(tmpdir):
     assert len(logger._buffer['raw_packet']) == 1
 
 def test_disable(tmpdir):
-    logger = HDF5Logger(directory=tmpdir)
+    logger = HDF5Logger(directory=str(tmpdir))
     logger.open()
 
     logger.disable()
@@ -29,14 +29,14 @@ def test_disable(tmpdir):
     assert len(logger._buffer['raw_packet']) == 0
 
 def test_open(tmpdir):
-    logger = HDF5Logger(directory=tmpdir)
+    logger = HDF5Logger(directory=str(tmpdir))
     logger.open()
 
     assert logger.is_enabled()
     assert logger.is_open()
 
 def test_flush(tmpdir):
-    logger = HDF5Logger(directory=tmpdir, buffer_length=5)
+    logger = HDF5Logger(directory=str(tmpdir), buffer_length=5)
     logger.open()
 
     logger.record([Packet()])
@@ -49,7 +49,7 @@ def test_flush(tmpdir):
     assert len(logger._buffer['raw_packet']) == 0
 
 def test_close(tmpdir):
-    logger = HDF5Logger(directory=tmpdir)
+    logger = HDF5Logger(directory=str(tmpdir))
     logger.open()
 
     logger.close()
@@ -57,7 +57,7 @@ def test_close(tmpdir):
     assert not logger.is_open()
 
 def test_record(tmpdir):
-    logger = HDF5Logger(directory=tmpdir, buffer_length=1)
+    logger = HDF5Logger(directory=str(tmpdir), buffer_length=1)
     logger.open()
 
     logger.record([Packet()], timestamp=5.0)
@@ -66,7 +66,7 @@ def test_record(tmpdir):
 @pytest.mark.filterwarnings("ignore:no IO object")
 def test_controller_write_capture(tmpdir):
     controller = Controller()
-    controller.logger = HDF5Logger(directory=tmpdir, buffer_length=1)
+    controller.logger = HDF5Logger(directory=str(tmpdir), buffer_length=1)
     controller.logger.open()
     controller.chips[0] = Chip(2, 0)
     chip = controller.chips[0]
@@ -78,7 +78,7 @@ def test_controller_read_capture(tmpdir):
     controller = Controller()
     controller.io = FakeIO()
     controller.io.queue.append(([Packet()], b'\x00\x00'))
-    controller.logger = HDF5Logger(directory=tmpdir, buffer_length=1)
+    controller.logger = HDF5Logger(directory=str(tmpdir), buffer_length=1)
     controller.logger.open()
     controller.run(0.1,'test')
     assert len(controller.logger._buffer) == 1


### PR DESCRIPTION
This obviates the need for special "tempfile" handling in the h5_logger unit tests since the built-in pytest tmpdir object can be used to specify a location for the temporary file. It also might make things more convenient when we're looking for places to save the log files.

As a bonus, the temporary files are saved for 3 test cycles before they are purged, so you can examine them if the tests fail.

Fixes #139 