### PR TITLE
Issue #145 / parse new zmq data formats

### DIFF
--- a/docs/api/format/index.rst
+++ b/docs/api/format/index.rst
@@ -7,5 +7,6 @@ The data formats used for LArPix are:
    :maxdepth: 2
 
    hdf5format
+   message_format
 
 :ref:`genindex`

--- a/docs/api/logger/h5_logger.rst
+++ b/docs/api/logger/h5_logger.rst
@@ -4,6 +4,4 @@ HDF5 Logger Interface
 .. autoclass:: larpix.logger.h5_logger.HDF5Logger
 
     .. autoattribute:: larpix.logger.h5_logger.HDF5Logger.VERSION
-    .. autoattribute:: larpix.logger.h5_logger.HDF5Logger.header_keys
     .. autoattribute:: larpix.logger.h5_logger.HDF5Logger.data_desc_map
-    .. autoattribute:: larpix.logger.h5_logger.HDF5Logger.data_desc

--- a/larpix/format/message_format.py
+++ b/larpix/format/message_format.py
@@ -13,7 +13,7 @@ from larpix.larpix import Packet, TimestampPacket
 
 def dataserver_message_decode(msgs, key_generator=None, version=(1,0), **kwargs):
     '''
-    Convert a list larpix data server messages into packets. A key generator
+    Convert a list of larpix data server messages into packets. A key generator
     should be provided if packets are to be used with an ``larpix.io.IO``
     object. The data server messages provide a ``chip_id`` and ``io_chain`` for
     keys. Additional keyword arguments can be passed along to the key generator.
@@ -50,24 +50,25 @@ def dataserver_message_encode(packets, key_parser=None, version=(1,0)):
     DAQ board messages are formatted using 8-byte words
 
         All messages:
-
          - byte[0] = major version
          - byte[1] = minor version
-         - byte[2] = message type ('D':LArPix data, 'T':Timestamp data, 'H': Heartbeat)
+         - byte[2] = message type
+
+            - ``b'D'``: LArPix data
+            - ``b'T'``: Timestamp data
+            - ``b'H'``: Heartbeat
 
         LArPix heartbeat messages:
-         - byte[3] = b'H'
-         - byte[4] = b'B'
-         - byte[5:7] = b'\x00'
+         - byte[3] = ``b'H'``
+         - byte[4] = ``b'B'``
+         - byte[5:7] are unused
 
         LArPix data messages:
-
-         - byte[3] = io chain
+         - byte[3] = io channel
          - bytes[4:7] are unused
-         - bytes[8:] are the raw LArPix UART bytes
+         - bytes[8:] = raw LArPix 7-byte UART words ending in a single null byte
 
         Timestamp data messages:
-
          - byte[3:7] are unused
          - byte[8:14] = 7-byte Unix timestamp
          - byte[15] is unused

--- a/larpix/format/message_format.py
+++ b/larpix/format/message_format.py
@@ -1,0 +1,79 @@
+'''
+The module contains all the message formats used by systems that interface
+with larpix-control:
+
+    - dataserver_message_encode: convert from packets to the data server messaging format
+    - dataserver_message_decode: convert from data server messaging format to packets
+
+'''
+import warnings
+
+from larpix.larpix import Packet
+
+def dataserver_message_decode(msgs, key_generator=None, version=(1,0), **kwargs):
+    '''
+    Convert a list larpix data server messages into packets. A key generator
+    should be provided if packets are to be used with an ``larpix.io.IO``
+    object. The data server messages provide a ``chip_id`` and ``io_chain`` for
+    keys. Additional keyword arguments can be passed along to the key generator.
+
+    '''
+    packets = []
+    for msg in msgs:
+        major, minor = [int(val) for val in msg[:2]]
+        if (major, minor) != version:
+            warnings.warn('Message version mismatch! Expected {}, received {}'.format(version, (major,minor)))
+        msg_type = msg[2:3]
+        if msg_type == b'T':
+            # FIX ME: once the TimestampPacket is merged in, this need to be updated
+            print('Timestamp message: {}'.format(int.from_bytes(msg[8:],byteorder='little')))
+        elif msg_type == b'D':
+            io_chain = int(msg[3])
+            payload = msg[8:]
+            print(len(payload))
+            if len(payload)%8 == 0:
+                for start_index in range(0, len(payload), 8):
+                    packet_bytes = payload[start_index:start_index+7]
+                    packets.append(Packet(packet_bytes))
+                    if key_generator:
+                        packets[-1].chip_key = key_generator(chip_id=packets[-1].chipid, io_chain=io_chain, **kwargs)
+    return packets
+
+def dataserver_message_encode(packets, key_parser=None, version=(1,0)):
+    '''
+    Convert a list of packets to larpix dataserver messages. A key parser must extract
+    the ``'io_chain'`` from the packet chip key.
+
+    DAQ board messages are formatted using 8-byte words
+
+        All messages:
+         - byte[0] = major version
+         - byte[1] = minor version
+         - byte[2] = message type ('D':LArPix data, 'T':Timestamp data)
+
+        LArPix data messages:
+         - byte[3] = io chain
+         - bytes[4:7] are unused
+         - bytes[8:] are the raw LArPix UART bytes
+
+        Timestamp data messages:
+         - byte[3:7] are unused
+         - byte[8:17] 8-byte Unix timestamp
+
+    '''
+    msgs = []
+    for packet in packets:
+        msg = b''
+        msg += bytes(version)
+        if isinstance(packet, Packet):
+            msg += b'D'
+            if key_parser:
+                msg += bytes(key_parser(packet.chip_key)['io_chain'])
+            else:
+                msg += bytes(1)
+            msg += bytes(4)
+        else:
+            msg += bytes(5)
+        msg += packet.bytes() + bytes(1)
+        msgs += [msg]
+    return msgs

--- a/larpix/format/message_format.py
+++ b/larpix/format/message_format.py
@@ -27,7 +27,8 @@ def dataserver_message_decode(msgs, key_generator=None, version=(1,0), **kwargs)
         msg_type = struct.unpack('c',msg[2:3])[0]
         if msg_type == b'T':
             # FIX ME: once the TimestampPacket is merged in, this need to be updated
-            print('Timestamp message: {}'.format(struct.unpack('<L',msg[8:])[0]))
+            timestamp = struct.unpack('L',msg[8:])[0]
+            print('Timestamp message: {}'.format(timestamp))
         elif msg_type == b'D':
             io_chain = struct.unpack('B',msg[3:4])[0]
             payload = msg[8:]
@@ -37,6 +38,8 @@ def dataserver_message_decode(msgs, key_generator=None, version=(1,0), **kwargs)
                     packets.append(Packet(packet_bytes))
                     if key_generator:
                         packets[-1].chip_key = key_generator(chip_id=packets[-1].chipid, io_chain=io_chain, **kwargs)
+        elif msg_type == b'H':
+            print('Heartbeat message: {}'.format(msg[3:]))
     return packets
 
 def dataserver_message_encode(packets, key_parser=None, version=(1,0)):
@@ -51,7 +54,12 @@ def dataserver_message_encode(packets, key_parser=None, version=(1,0)):
 
          - byte[0] = major version
          - byte[1] = minor version
-         - byte[2] = message type ('D':LArPix data, 'T':Timestamp data)
+         - byte[2] = message type ('D':LArPix data, 'T':Timestamp data, 'H': Heartbeat)
+
+        LArPix heartbeat messages:
+         - byte[3] = b'H'
+         - byte[4] = b'B'
+         - byte[5:8] = b'\x00'
 
         LArPix data messages:
 

--- a/larpix/io/__init__.py
+++ b/larpix/io/__init__.py
@@ -68,7 +68,7 @@ class IO(object):
         :returns: ``dict`` of IO information contained in key
 
         '''
-        if not cls.is_valid_chip_key(key):
+        if not IO.is_valid_chip_key(key):
             raise ValueError('invalid chip key for IO type, see docs for description of valid chip keys')
         empty_dict = {}
         return empty_dict

--- a/larpix/io/multizmq_io.py
+++ b/larpix/io/multizmq_io.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 
 from larpix.io import IO
 from larpix.larpix import Packet
+from larpix.format.message_format import dataserver_message_decode
 
 class MultiZMQ_IO(IO):
     '''
@@ -40,16 +41,23 @@ class MultiZMQ_IO(IO):
             receive_address = 'tcp://' + address + ':5556'
             self.senders[address].connect(send_address)
             self.receivers[address].connect(receive_address)
-        self.sender_replies = defaultdict(list)
+        self._sender_replies = defaultdict(list)
         self.poller = zmq.Poller()
         for receiver in self.receivers.values():
             self.poller.register(receiver, zmq.POLLIN)
 
+    @property
+    def sender_replies(self):
+        return self._sender_replies
+    @sender_replies.setter
+    def sender_replies(self, val):
+        self._sender_replies = val
+
     def send(self, packets):
         self.sender_replies = defaultdict(list)
         send_time = time.time()
-        addresses = [self.parse_chip_key(packet.chip_key)['address'] for packet in packets]
-        msg_datas = self.encode(packets)
+        addresses = [MultiZMQ_IO.parse_chip_key(packet.chip_key)['address'] for packet in packets]
+        msg_datas = MultiZMQ_IO.encode(packets)
         for address, msg_data in zip(addresses, msg_datas):
             tosend = b'SNDWORD ' + msg_data
             self.senders[address].send(tosend)
@@ -99,7 +107,9 @@ class MultiZMQ_IO(IO):
 
         :returns: ``dict`` with keys ``('chip_id', 'io_chain', 'addresss')``
         '''
-        return_dict = super(MultiZMQ_IO, cls).parse_chip_key(key)
+        return_dict = {}
+        if not MultiZMQ_IO.is_valid_chip_key(key):
+            raise ValueError('invalid MultiZMQ_IO key: {}'.format(key))
         parsed_key = key.split('/')
         return_dict['chip_id'] = int(parsed_key[2])
         return_dict['io_chain'] = int(parsed_key[1])
@@ -136,15 +146,7 @@ class MultiZMQ_IO(IO):
         Convert a list ZMQ messages into packets
 
         '''
-        packets = []
-        for msg in msgs:
-            if len(msg) % 8 == 0:
-                for start_index in range(0, len(msg), 8):
-                    packet_bytes = msg[start_index:start_index+7]
-                    packets.append(Packet(packet_bytes))
-                    packets[-1].chip_key = cls.generate_chip_key(
-                        chip_id=packets[-1].chipid, io_chain=io_chain, address=str(address))
-        return packets
+        return dataserver_message_decode(msgs, key_generator=cls.generate_chip_key, version=(1,0), address=address, **kwargs)
 
     @classmethod
     def encode(cls, packets):
@@ -153,9 +155,9 @@ class MultiZMQ_IO(IO):
         '''
         msg_data = []
         if sys.version_info[0] < 3:
-            msg_data = [b'0x00%s 0' % packet.bytes()[::-1].encode('hex') for packet in packets]
+            msg_data = [b'0x00%s %d' % (packet.bytes()[::-1].encode('hex'), cls.parse_chip_key(packet.chip_key)['io_chain']) for packet in packets]
         else:
-            msg_data = [b'0x00%s 0' % packet.bytes()[::-1].hex().encode() for packet in packets]
+            msg_data = [b'0x00%s %d' % (packet.bytes()[::-1].hex().encode(), cls.parse_chip_key(packet.chip_key)['io_chain'])for packet in packets]
         return msg_data
 
     def empty_queue(self):

--- a/larpix/io/zmq_io.py
+++ b/larpix/io/zmq_io.py
@@ -105,17 +105,6 @@ class ZMQ_IO(MultiZMQ_IO):
                 ', requires {}, received {}'.format(req_fields, kwargs.keys()))
         return '{io_chain}-{chip_id}'.format(**kwargs)
 
-    # commented out because the inherited methods work just as well
-    # @classmethod
-    # def decode(cls, msgs, io_chain=0, **kwargs):
-    #     '''
-    #     Convert a list ZMQ messages into packets
-    #     '''
-    #     return super(ZMQ_IO, cls).decode(msgs, io_chain=io_chain, **kwargs)
-
-    # def empty_queue(self):
-    #     return super(ZMQ_IO, self).empty_queue()
-
     def reset(self):
         '''
         Send a reset pulse to the LArPix ASICs.

--- a/test/test_message_format.py
+++ b/test/test_message_format.py
@@ -1,9 +1,17 @@
-from larpix.larpix import Chip, Packet
+from larpix.larpix import Chip, Packet, TimestampPacket
 from larpix.format.message_format import dataserver_message_decode, dataserver_message_encode
 
 def test_message_format_test_packets():
     c = Chip(5,'1-5')
     expected_packets = c.get_configuration_packets(Packet.CONFIG_READ_PACKET)
     expected_messages = [b'\x01\x00'+b'D'+b'\x00'*5 + packet.bytes() + b'\x00' for packet in expected_packets]
+    ts_packet = TimestampPacket(timestamp=123456789)
+    expected_packets += [ts_packet]
+    expected_messages += [b'\x01\x00'+b'T'+b'\x00'*5 + ts_packet.bytes() + b'\x00']
+    print(expected_packets[-1])
+    print(expected_messages[-1])
+    print(dataserver_message_decode(expected_messages)[-1])
+    print(expected_messages[-1])
+    print(dataserver_message_encode(expected_packets)[-1])
     assert expected_messages == dataserver_message_encode(expected_packets)
     assert expected_packets == dataserver_message_decode(expected_messages)

--- a/test/test_message_format.py
+++ b/test/test_message_format.py
@@ -4,6 +4,6 @@ from larpix.format.message_format import dataserver_message_decode, dataserver_m
 def test_message_format_test_packets():
     c = Chip(5,'1-5')
     expected_packets = c.get_configuration_packets(Packet.CONFIG_READ_PACKET)
-    expected_messages = [bytes([1,0])+b'D'+bytes([0,0,0,0,0]) + packet.bytes() + bytes(1) for packet in expected_packets]
+    expected_messages = [b'\x01\x00'+b'D'+b'\x00'*5 + packet.bytes() + b'\x00' for packet in expected_packets]
     assert expected_messages == dataserver_message_encode(expected_packets)
     assert expected_packets == dataserver_message_decode(expected_messages)

--- a/test/test_message_format.py
+++ b/test/test_message_format.py
@@ -1,0 +1,9 @@
+from larpix.larpix import Chip, Packet
+from larpix.format.message_format import dataserver_message_decode, dataserver_message_encode
+
+def test_message_format_test_packets():
+    c = Chip(5,'1-5')
+    expected_packets = c.get_configuration_packets(Packet.CONFIG_READ_PACKET)
+    expected_messages = [bytes([1,0])+b'D'+bytes([0,0,0,0,0]) + packet.bytes() + bytes(1) for packet in expected_packets]
+    assert expected_messages == dataserver_message_encode(expected_packets)
+    assert expected_packets == dataserver_message_decode(expected_messages)

--- a/test/test_multizmq_io.py
+++ b/test/test_multizmq_io.py
@@ -7,6 +7,7 @@ import pytest
 import os
 from larpix.larpix import Packet
 from larpix.io.multizmq_io import MultiZMQ_IO
+from larpix.format.message_format import dataserver_message_decode, dataserver_message_encode
 
 def test_generate_chip_key():
     chip_id = 125
@@ -30,11 +31,21 @@ def test_parse_chip_key():
     assert MultiZMQ_IO.parse_chip_key(key) == expected
 
 def test_encode():
-    test_bytes = b'\x00\x01\x02\x03\x04\x05\x06'
-    expected = [b'0x0006050403020100 0']
-    assert MultiZMQ_IO.encode([Packet(test_bytes)]) == expected
+    chip_id = 64
+    io_chain = 1
+    address = 'localhost'
+    test_packet = Packet(b'\x00\x01\x02\x03\x04\x05\x06')
+    test_packet.chip_key = MultiZMQ_IO.generate_chip_key(address=address, chip_id=chip_id, io_chain=io_chain)
+    test_bytes = b'0x0006050403020100 1'
+    expected = [test_bytes]
+    assert MultiZMQ_IO.encode([test_packet]) == expected
 
 def test_decode():
-    test_bytes = b'\x00\x06\x05\x04\x03\x02\x01\x00'
-    expected = [Packet(test_bytes[:-1])]
-    assert MultiZMQ_IO.decode([test_bytes]) == expected
+    chip_id = 64
+    io_chain = 1
+    address = 'localhost'
+    test_packet = Packet(b'\x00\x01\x02\x03\x04\x05\x06')
+    test_packet.chip_key = MultiZMQ_IO.generate_chip_key(address=address, chip_id=chip_id, io_chain=io_chain)
+    test_bytes = dataserver_message_encode([test_packet])
+    expected = [test_packet]
+    assert MultiZMQ_IO.decode(test_bytes, address=address) == expected

--- a/test/test_zmq_io.py
+++ b/test/test_zmq_io.py
@@ -7,6 +7,7 @@ import pytest
 import os
 from larpix.larpix import Packet
 from larpix.io.zmq_io import ZMQ_IO
+from larpix.format.message_format import dataserver_message_encode
 
 def test_generate_chip_key():
     chip_id = 125
@@ -27,11 +28,19 @@ def test_parse_chip_key():
     assert ZMQ_IO.parse_chip_key(key) == expected
 
 def test_encode():
-    test_bytes = b'\x00\x01\x02\x03\x04\x05\x06'
-    expected = [b'0x0006050403020100 0']
-    assert ZMQ_IO.encode([Packet(test_bytes)]) == expected
+    chip_id = 64
+    io_chain = 1
+    test_packet = Packet(b'\x00\x01\x02\x03\x04\x05\x06')
+    test_packet.chip_key = ZMQ_IO.generate_chip_key(chip_id=chip_id, io_chain=io_chain)
+    test_bytes = b'0x0006050403020100 1'
+    expected = [test_bytes]
+    assert ZMQ_IO.encode([test_packet]) == expected
 
 def test_decode():
-    test_bytes = b'\x00\x06\x05\x04\x03\x02\x01\x00'
-    expected = [Packet(test_bytes[:-1])]
-    assert ZMQ_IO.decode([test_bytes]) == expected
+    chip_id = 64
+    io_chain = 1
+    test_packet = Packet(b'\x00\x01\x02\x03\x04\x05\x06')
+    test_packet.chip_key = ZMQ_IO.generate_chip_key(chip_id=chip_id, io_chain=io_chain)
+    test_bytes = dataserver_message_encode([test_packet])
+    expected = [test_packet]
+    assert ZMQ_IO.decode(test_bytes) == expected


### PR DESCRIPTION
@samkohn, I've implemented a reader for our new and improved "Igor dataserver format". Basically, the new format includes a header word (8-bytes) included with every transmission. The first two bytes are reserved for versioning and the third is reserved for the message type (e.g. timestamp, data, others?). The remaining bytes are particular to the message type. The message "payload" can then be any number of 8-byte words following the header (so we are not necessarily stuck with an 8-byte timestamp at this point). I've implemented this and added a basic test.

I don't think that this format significantly impacts the data rate - only one header message is sent per DAQ board fifo flush (1024 packets). So, if the data rate is high, the headers are an insignificant fraction of the data.

Since it requires #140 for the Timestamp package, I've submitted a PR now, but I will update this once that gets merged in. I also haven't checked python 2 compatibility yet. But I have tested it with a test DAQ board with an upgraded dataserver and it gets all the endian-ness correct.