### PR TITLE
Update HDF5Logger + docs + tutorial to LArPix+HDF5v1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ when the datafile was created and the file format version number, stored as
 attributes.
 
 ```python
-list(datafile.keys()) # ['_header', 'raw_packet']
+list(datafile.keys()) # ['_header', 'messages', 'packets']
 list(datafile['_header'].attrs) # ['created', 'modified', version']
 ```
 

--- a/docs/api/logger/h5_logger.rst
+++ b/docs/api/logger/h5_logger.rst
@@ -2,6 +2,3 @@ HDF5 Logger Interface
 -----------------------
 
 .. autoclass:: larpix.logger.h5_logger.HDF5Logger
-
-    .. autoattribute:: larpix.logger.h5_logger.HDF5Logger.VERSION
-    .. autoattribute:: larpix.logger.h5_logger.HDF5Logger.data_desc_map

--- a/larpix/logger/h5_logger.py
+++ b/larpix/logger/h5_logger.py
@@ -6,28 +6,21 @@ import h5py
 
 from larpix.logger import Logger
 from larpix.larpix import Packet, TimestampPacket
-from larpix.format.hdf5format import to_file, dtypes
+from larpix.format.hdf5format import to_file, latest_version
 
 class HDF5Logger(Logger):
     '''
-    The HDF5Logger is logger class for logging packets to an hdf5 file format.
+    The HDF5Logger is a logger class for logging packets to the LArPix+HDF5 format.
 
-    The HDF5 file is be formatted as follows:
+    The file format is implemented in ``larpix.format.hdf5format``,
+    which also contains a function to convert back from LArPix+HDF5 to
+    LArPix packets.
 
-    *Groups:* ``_header``
-
-        ``_header`` group: contains additional file information within its ``attrs``.
-        The available fields are indicated in ``HDF5Logger.header_keys``. The header
-        is initialized upon opening the logger.
-
-    *Datasets:* specified by ``HDF5Logger.dataset_list`` and ``HDF5Logger.data_desc_map``
-
-        ``HDF5Logger.dataset_list``: Lists the datasets that are
-        produced.
-
-        ``HDF5Logger.data_desc_map``: This maps specifies the mapping between
-        larpix core datatypes and the dataset within the HDF5 file. E.g.,
-        ``larpix.Packet`` objects are stored in ``'raw_packet'``.
+    :var data_desc_map: specifies the mapping between
+        objects sent to the logger and the specific logger buffer to store them
+        in. As of LArPix+HDF5 version 1.0 and larpix-control version
+        2.3.0 there is only one buffer called ``'packets'`` which stores
+        all of the data to send to LArPix+HDF5.
 
     :param filename: filename to store data (appended to ``directory``)
         (optional, default: ``None``)
@@ -35,24 +28,24 @@ class HDF5Logger(Logger):
         buffer to the file (optional, default: ``10000``)
     :param directory: the directory to save the data in (optional,
         default: '')
+    :param version: the format version of LArPix+HDF5 to use (optional,
+        default: ``larpix.format.hdf5format.latest_version``)
 
     '''
-    VERSION = '0.0'
     data_desc_map = {
-        Packet: 'raw_packet',
-        TimestampPacket: 'raw_packet',
+        Packet: 'packets',
+        TimestampPacket: 'packets',
     }
-    dataset_list = list(dtypes[VERSION].keys())
 
     def __init__(self, filename=None, buffer_length=10000,
-            directory=''):
+            directory='', version=latest_version):
+        self.version = version
         self.filename = filename
         self.directory = directory
         self.datafile = None
         self.buffer_length = buffer_length
 
-        self._buffer = dict([(dataset, []) for dataset in
-            self.dataset_list])
+        self._buffer = {'packets': []}
         self._is_enabled = False
         self._is_open = False
 
@@ -145,7 +138,7 @@ class HDF5Logger(Logger):
         if not self.filename:
             self.filename = self._default_filename()
         self.filename = os.path.join(self.directory, self.filename)
-        to_file(self.filename, [], version=self.VERSION)
+        to_file(self.filename, [], version=self.version)
         self._is_open = True
         self._is_enabled = enable
 
@@ -167,6 +160,6 @@ class HDF5Logger(Logger):
         '''
         if not self.is_open():
             return
-        to_file(self.filename, self._buffer['raw_packet'],
-                version=self.VERSION)
-        self._buffer['raw_packet'] = []
+        to_file(self.filename, self._buffer['packets'],
+                version=self.version)
+        self._buffer['packets'] = []

--- a/larpix/logger/h5_logger.py
+++ b/larpix/logger/h5_logger.py
@@ -67,6 +67,7 @@ class HDF5Logger(Logger):
     def record(self, data, direction=Logger.WRITE):
         '''
         Send the specified data to log file
+
         .. note:: buffer is flushed after all ``data`` is placed in buffer, this
             means that the buffer size will exceed the set value temporarily
 

--- a/test/test_h5_logger.py
+++ b/test/test_h5_logger.py
@@ -17,7 +17,7 @@ def test_enable(tmpdir):
     logger.enable()
     assert logger.is_enabled()
     logger.record([Packet()])
-    assert len(logger._buffer['raw_packet']) == 1
+    assert len(logger._buffer['packets']) == 1
 
 def test_disable(tmpdir):
     logger = HDF5Logger(directory=str(tmpdir))
@@ -26,7 +26,7 @@ def test_disable(tmpdir):
     logger.disable()
     assert not logger.is_enabled()
     logger.record([Packet()])
-    assert len(logger._buffer['raw_packet']) == 0
+    assert len(logger._buffer['packets']) == 0
 
 def test_open(tmpdir):
     logger = HDF5Logger(directory=str(tmpdir))
@@ -40,13 +40,13 @@ def test_flush(tmpdir):
     logger.open()
 
     logger.record([Packet()])
-    assert len(logger._buffer['raw_packet']) == 1
+    assert len(logger._buffer['packets']) == 1
     logger.flush()
-    assert len(logger._buffer['raw_packet']) == 0
+    assert len(logger._buffer['packets']) == 0
     logger.record([Packet()]*5)
-    assert len(logger._buffer['raw_packet']) == 5
+    assert len(logger._buffer['packets']) == 5
     logger.record([Packet()])
-    assert len(logger._buffer['raw_packet']) == 0
+    assert len(logger._buffer['packets']) == 0
 
 def test_close(tmpdir):
     logger = HDF5Logger(directory=str(tmpdir))
@@ -61,9 +61,9 @@ def test_record(tmpdir):
     logger.open()
 
     logger.record([Packet()])
-    assert len(logger._buffer['raw_packet']) == 1
+    assert len(logger._buffer['packets']) == 1
     logger.record([TimestampPacket(timestamp=123)])
-    assert len(logger._buffer['raw_packet']) == 2
+    assert len(logger._buffer['packets']) == 2
 
 @pytest.mark.filterwarnings("ignore:no IO object")
 def test_controller_write_capture(tmpdir, chip):
@@ -73,7 +73,7 @@ def test_controller_write_capture(tmpdir, chip):
     controller.chips[chip.chip_key] = chip
     controller.write_configuration(chip.chip_key, 0)
     packet = chip.get_configuration_packets(Packet.CONFIG_WRITE_PACKET)[0]
-    assert len(controller.logger._buffer) == 1
+    assert len(controller.logger._buffer['packets']) == 1
 
 def test_controller_read_capture(tmpdir):
     controller = Controller()
@@ -82,4 +82,4 @@ def test_controller_read_capture(tmpdir):
     controller.logger = HDF5Logger(directory=str(tmpdir), buffer_length=1)
     controller.logger.open()
     controller.run(0.1,'test')
-    assert len(controller.logger._buffer) == 1
+    assert len(controller.logger._buffer['packets']) == 1

--- a/test/test_tutorial.py
+++ b/test/test_tutorial.py
@@ -151,12 +151,14 @@ def test_tutorial(capsys, tmpdir, temp_logfilename):
     datafile = h5py.File(tmpdir.join(temp_logfilename))
 
 
-    assert list(datafile.keys()) == ['_header', 'raw_packet']
+    assert '_header' in datafile.keys()
+    assert 'packets' in datafile.keys()
+    assert 'messages' in datafile.keys()
     assert list(datafile['_header'].attrs) == ['created', 'modified', 'version']
 
 
-    raw_value = datafile['raw_packet'][0] # e.g. (1.56030174e+09, b'0-246', 3, 246, 1, 1, -1, -1, -1, -1, -1, -1, 0, 0)
-    raw_values = datafile['raw_packet'][-100:] # last 100 packets in file
+    raw_value = datafile['packets'][0] # e.g. (b'0-246', 3, 246, 1, 1, -1, -1, -1, -1, -1, -1, 0, 0)
+    raw_values = datafile['packets'][-100:] # last 100 packets in file
 
 
     packet_repr = raw_values[0:1]


### PR DESCRIPTION
Fix up some outdated descriptions, autoattribute documentation, and tutorial code and tests.

- Move ``HDF5Logger.VERSION`` (class attribute) to ``self.version`` (HDF5Logger instance attribute), defaults on initialization to ``larpix.format.hdf5format.latest_version``.
- Manually construct the ``_buffer`` object since it's not so simple to create it based on the LArPix+HDF5 ``dtype``. (Rename ``_buffer['raw_packet']`` to ``_buffer['packets']`` independent of the format version.)
- Remove the HDF5 format description from HDF5Logger. Instead, refer to the ``hdf5format`` docs.