### PR TITLE
Fix networking bug in test_tutorial (ugh)

### DIFF
--- a/larpix/configs/io/loopback.json
+++ b/larpix/configs/io/loopback.json
@@ -1,0 +1,7 @@
+{
+    "_config_type": "io",
+    "io_class": "ZMQ_IO",
+    "io_group": [
+        [1, "localhost"]
+    ]
+}

--- a/test/test_tutorial.py
+++ b/test/test_tutorial.py
@@ -174,7 +174,7 @@ def test_running_with_bern_daq():
     from larpix.io.zmq_io import ZMQ_IO
 
     controller = Controller()
-    controller.io = ZMQ_IO(config_filepath='io/daq-srv1.json')
+    controller.io = ZMQ_IO(config_filepath='io/loopback.json')
 
     controller.load('controller/pcb-2_chip_info.json')
 


### PR DESCRIPTION
Fixes #165

ZMQ hangs in context.term if
1. the socket connects to an address ending in ".local" that does not
    exist
2. 5 seconds have not yet elapsed, per attempted socket connect

This seems to only be present in our test_tutorial.py script. I fixed it
by replacing the daq-srv1.json config call with a new loopback.json file
that just connects to localhost.
