### PR TITLE
Add ability to alter the apparent channel from a given ZMQ_IO channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,11 @@ This should give you a quiet state with no data packets. Occasionally, there can
 be a few packets left in one of the system buffers (LArPix, FPGA, DAQ server). A
 second run command should return without any new packets.
 
+If you are using the v1.5 anode, you may need to reconfigure the miso/mosi mapping (since the miso/mosi pair for a daisy chain is not necessarily on a single channel). To do this, pass a `miso_map` or `mosi_map` to the `ZMQ_IO` object on initialization:
+```python
+>>> controller.io = ZMQ_IO(config_filepath='<path to config>', miso_map={2:1}) # relabels packets received on channel 2 as packets from channel 1
+```
+
 ### Check configurations
 If you are still receiving data, you can check that the hardware chip configuration
 match the software chip configurations with

--- a/larpix/io/zmq_io.py
+++ b/larpix/io/zmq_io.py
@@ -22,8 +22,8 @@ class ZMQ_IO(MultiZMQ_IO):
     '''
     _valid_config_classes = MultiZMQ_IO._valid_config_classes + ['ZMQ_IO']
 
-    def __init__(self, config_filepath=None):
-        super(ZMQ_IO, self).__init__(config_filepath=config_filepath)
+    def __init__(self, config_filepath=None, **kwargs):
+        super(ZMQ_IO, self).__init__(config_filepath=config_filepath, **kwargs)
         self._address = list(self._io_group_table.values())[0]
 
     def load(self, filepath=None):
@@ -31,6 +31,15 @@ class ZMQ_IO(MultiZMQ_IO):
         if len(self._io_group_table.inv) != 1:
             raise RuntimeError('multiple adresses found in configuration - use '
                 'MultiZMQ_IO if you\'d like to connect to multiple systems')
+
+    def decode(self, msgs, **kwargs):
+        '''
+        Convert a list ZMQ messages into packets
+
+        '''
+        if not 'address' in kwargs:
+            kwargs['address'] = self._address
+        return super(ZMQ_IO, self).decode(msgs, **kwargs)
 
     @property
     def sender(self):
@@ -66,18 +75,14 @@ class ZMQ_IO(MultiZMQ_IO):
         if not all([key in kwargs for key in req_fields]):
             raise ValueError('Missing fields required to generate chip id'
                 ', requires {}, received {}'.format(req_fields, kwargs.keys()))
+        io_channel = kwargs['io_chain']
+        if io_channel in self._miso_map:
+            io_channel = self._miso_map[io_channel]
         return Key.from_dict(dict(
-                io_channel = kwargs['io_chain'],
+                io_channel = io_channel,
                 chip_id = kwargs['chip_id'],
                 io_group = self._io_group_table.inv[self._address]
             ))
-
-    def decode(self, msgs, **kwargs):
-        '''
-        Convert a list ZMQ messages into packets
-
-        '''
-        return super(ZMQ_IO, self).decode(msgs, address=self._address, **kwargs)
 
     def reset(self):
         '''


### PR DESCRIPTION
Allows for users to specify a remapping of io channels so that packets sent/received on one channel can be made to appear to arrive on another channel. This is a temporary fix for the v1.5 anode where packets sent on channel 1 are received on channel 2.