### PR TITLE
Refactor common Logger subclass logic into Logger class

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ example for you to play around with:
 >>> controller = Controller()
 >>> controller.io = FakeIO()
 >>> controller.logger = StdoutLogger(buffer_length=0)
->>> controller.logger.open()
+>>> controller.logger.enable()
 >>> chip1 = controller.add_chip('1-1-1')  # (access key)
 >>> chip1.config.global_threshold = 25
 >>> controller.write_configuration('1-1-1', 25) # chip key, register 25
@@ -129,7 +129,7 @@ from larpix.logger.stdout_logger import StdoutLogger
 controller = Controller()
 controller.io = FakeIO()
 controller.logger = StdoutLogger(buffer_length=0)
-controller.logger.open()
+controller.logger.enable()
 ```
 
 The ``FakeIO`` object imitates a real IO interface for testing purposes.
@@ -141,9 +141,9 @@ the code.
 
 Similarly, the ``StdoutLogger`` mimics the real logger interface for testing. It
 prints nicely formatted records of read / write commands to stdout every
-``buffer_length`` packets. The logger interface requires opening or enabling the
+``buffer_length`` packets. The logger interface requires enabling the
 logger before messages will be stored. Before ending the python session, every
-logger should be closed to flush any remaining packets stored in the buffer.
+logger should be disabled to flush any remaining packets stored in the buffer.
 
 ### Set up LArPix Chips
 
@@ -418,7 +418,14 @@ To create a permanent record of communications with the LArPix ASICs, an
 ```python
 from larpix.logger.h5_logger import HDF5Logger
 controller.logger = HDF5Logger(filename=None, buffer_length=10000) # a filename of None uses the default filename formatting
-controller.logger.open() # opens hdf5 file and starts tracking all communications
+controller.logger.enable() # starts tracking all communications
+```
+
+You can also initialize and enable the logger in one call by passing the
+``enabled`` keyword argument (which defaults to ``False``):
+
+```
+controller.logger = HDF5Logger(filename=None, enabled=True)
 ```
 
 Now whenever you send or receive packets, they will be captured by the logger
@@ -441,13 +448,13 @@ controller.logger.enable() # start tracking again
 controller.logger.is_enabled() # returns True if tracking
 ```
 
-Once you have finished your tests, be sure to close the logger. If you do not,
-the file may become corrupted and you may lose data. We strongly recommend
+Once you have finished your tests, be sure to disable the logger. If you do not,
+you will lose any data still in the buffer of the logger object. We strongly recommend
 wrapping logger code with a `try, except` statement if you can. Any remaining
-packets in the buffer are flushed to the file upon closing.
+packets in the buffer are flushed to the file upon disabling.
 
 ```python
-controller.logger.close()
+controller.logger.disable()
 ```
 
 ### Viewing data from the HDF5Logger

--- a/larpix/logger/__init__.py
+++ b/larpix/logger/__init__.py
@@ -66,7 +66,7 @@ class Logger(object):
         Returns the value of the internal state "open/closed" (``True``
         if open).
 
-        .. deprecated:: 3.0.0
+        .. deprecated:: 2.4.0
            ``open``, ``close``, and ``is_open`` are deprecated and will
            be removed in the next major release of larpix-control.
 
@@ -83,7 +83,7 @@ class Logger(object):
 
         :param enable: whether to enable this logger
 
-        .. deprecated:: 3.0.0
+        .. deprecated:: 2.4.0
            ``open``, ``close``, and ``is_open`` are deprecated and will
            be removed in the next major release of larpix-control.
 
@@ -102,7 +102,7 @@ class Logger(object):
         Change internal state to "closed" (meaningless) and disable this
         logger (meaningful).
 
-        .. deprecated:: 3.0.0
+        .. deprecated:: 2.4.0
            ``open``, ``close``, and ``is_open`` are deprecated and will
            be removed in the next major release of larpix-control.
 

--- a/larpix/logger/__init__.py
+++ b/larpix/logger/__init__.py
@@ -14,7 +14,7 @@ class Logger(object):
     #: Flag to indicate packets were received from ASICs
     READ = 1
 
-    def __init__(self, *args, enabled=False, **kwargs):
+    def __init__(self, enabled=False, *args, **kwargs):
         '''
         Create new logger instance.
 

--- a/larpix/logger/__init__.py
+++ b/larpix/logger/__init__.py
@@ -1,3 +1,6 @@
+import warnings
+warnings.simplefilter('default', DeprecationWarning)
+
 class Logger(object):
     '''
     Base class for larpix logger objects that explicity describes the necessary
@@ -11,12 +14,13 @@ class Logger(object):
     #: Flag to indicate packets were received from ASICs
     READ = 1
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, enabled=False, **kwargs):
         '''
         Create new logger instance.
 
         '''
-        pass
+        self._enabled = enabled
+        self._open = False
 
     def record(self, data, direction=0, *args, **kwargs):
         '''
@@ -37,48 +41,77 @@ class Logger(object):
         ``disable()`` command should be reflected in the log.
 
         '''
-        pass
+        return self._enabled
 
     def enable(self):
         '''
         Enable logger
 
         '''
-        pass
+        self._enabled = True
 
     def disable(self):
         '''
         Disable logger
 
+        .. note:: This flushes any data in the buffer before disabling
+
         '''
-        pass
+        if self._enabled:
+            self.flush()
+        self._enabled = False
 
     def is_open(self):
         '''
-        Check if logger is open. Opening a logger is only necessary if it is
-        file-based. Regardless of the open/closed status, all data passed into
-        ``record()`` between an ``enable()`` and ``disable()`` command should be
-        reflected in the log.
+        Returns the value of the internal state "open/closed" (``True``
+        if open).
+
+        .. deprecated:: 3.0.0
+           ``open``, ``close``, and ``is_open`` are deprecated and will
+           be removed in the next major release of larpix-control.
 
         '''
-        pass
+        warnings.warn('open/close/is_open are deprecated and will be removed '
+            'in the next major release of larpix-control.',
+            DeprecationWarning, 2)
+        return self._open
 
     def open(self, enable=True):
         '''
-        Open logger if it is not already.
+        Change internal state to "open" (meaningless), and if
+        ``enable``, enable this logger (meaningful).
 
-        .. note:: You must close a logger after opening!
+        :param enable: whether to enable this logger
 
-        :param enable: ``True`` if you want to enable the logger after opening
+        .. deprecated:: 3.0.0
+           ``open``, ``close``, and ``is_open`` are deprecated and will
+           be removed in the next major release of larpix-control.
 
         '''
+        warnings.warn('open/close/is_open are deprecated and will be removed '
+            'in the next major release of larpix-control.',
+            DeprecationWarning, 2)
+        if enable:
+            self.enable()
+        self._open = True
+        return
+
 
     def close(self):
         '''
-        Close logger if it is not already
+        Change internal state to "closed" (meaningless) and disable this
+        logger (meaningful).
+
+        .. deprecated:: 3.0.0
+           ``open``, ``close``, and ``is_open`` are deprecated and will
+           be removed in the next major release of larpix-control.
 
         '''
-        pass
+        warnings.warn('open/close/is_open are deprecated and will be removed '
+            'in the next major release of larpix-control.',
+            DeprecationWarning, 2)
+        self._open = False
+        self.disable()
 
     def flush(self):
         '''

--- a/larpix/logger/stdout_logger.py
+++ b/larpix/logger/stdout_logger.py
@@ -12,11 +12,11 @@ class StdoutLogger(Logger):
     :param buffer_length: how many data messages to hang on to before flushing buffer to stdout
     :param mode: how logger file should be opened (not implemented in ``StdoutLogger``)
     '''
-    def __init__(self, filename=None, buffer_length=0, mode='wa'):
+    def __init__(self, filename=None, buffer_length=0, mode='wa',
+            enabled=False):
+        super(StdoutLogger, self).__init__(enabled=enabled)
         self.filename = filename
         self._buffer = []
-        self._is_enabled = False
-        self._is_open = False
         self.buffer_length = buffer_length
 
     def record(self, data, direction=0):
@@ -27,10 +27,8 @@ class StdoutLogger(Logger):
         :param direction: 0 if packets were sent to ASICs, 1 if packets
             were received from ASICs. optional, default=0
         '''
-        if not self._is_enabled:
+        if not self.is_enabled():
             return
-        if not self._is_open:
-            self.open()
         if not isinstance(data,list):
             raise ValueError('data must be a list')
 
@@ -38,50 +36,6 @@ class StdoutLogger(Logger):
 
         if len(self._buffer) > self.buffer_length:
             self.flush()
-
-    def is_enabled(self):
-        '''
-        Check if logger is enabled
-        '''
-        return self._is_enabled
-
-    def enable(self):
-        '''
-        Allow the logger to record data
-        '''
-        self._is_enabled = True
-
-    def disable(self):
-        '''
-        Stop the logger from recording data without closing
-        '''
-        self.flush()
-        self._is_enabled = False
-
-    def is_open(self):
-        '''
-        Check if logger is open
-        '''
-        return self._is_open
-
-    def open(self, enable=True):
-        '''
-        Open logger if it is not already
-
-        :param enable: ``True`` if you want to enable the logger after opening
-        '''
-        self._is_open = True
-        self._is_enabled = enable
-
-    def close(self):
-        '''
-        Close logger if it is not already
-
-        .. note:: This flushes any data in the buffer before closing
-        '''
-        self.flush()
-        self._is_open = False
-        self._is_enabled = False
 
     def flush(self):
         '''

--- a/test/test_h5_logger.py
+++ b/test/test_h5_logger.py
@@ -10,34 +10,56 @@ from larpix.larpix import Packet, Controller, Chip, TimestampPacket
 from larpix.io.fakeio import FakeIO
 from larpix.logger.h5_logger import HDF5Logger
 
-def test_enable(tmpdir):
+def test_enable_deprecated_3_0_0(tmpdir):
     logger = HDF5Logger(directory=str(tmpdir),buffer_length=1)
-    logger.open()
+    with pytest.warns(DeprecationWarning):
+        logger.open()
 
     logger.enable()
     assert logger.is_enabled()
     logger.record([Packet()])
     assert len(logger._buffer['packets']) == 1
 
-def test_disable(tmpdir):
+def test_enable(tmpdir):
     logger = HDF5Logger(directory=str(tmpdir))
-    logger.open()
+    assert not logger.is_enabled()
+    logger.record([Packet()])
+    assert len(logger._buffer['packets']) == 0
+    logger.enable()
+    assert logger.is_enabled()
+    logger.record([Packet()])
+    assert len(logger._buffer['packets']) == 1
+
+def test_disable_deprecated_3_0_0(tmpdir):
+    logger = HDF5Logger(directory=str(tmpdir))
+    with pytest.warns(DeprecationWarning):
+        logger.open()
 
     logger.disable()
     assert not logger.is_enabled()
     logger.record([Packet()])
     assert len(logger._buffer['packets']) == 0
 
-def test_open(tmpdir):
+def test_disable(tmpdir):
+    logger =HDF5Logger(directory=str(tmpdir), enabled=True)
+    logger.disable()
+    assert not logger.is_enabled()
+    logger.record([Packet()])
+    assert len(logger._buffer['packets']) == 0
+
+def test_open_deprecated_3_0_0(tmpdir):
     logger = HDF5Logger(directory=str(tmpdir))
-    logger.open()
+    with pytest.warns(DeprecationWarning):
+        logger.open()
 
     assert logger.is_enabled()
-    assert logger.is_open()
+    with pytest.warns(DeprecationWarning):
+        assert logger.is_open()
 
-def test_flush(tmpdir):
+def test_flush_deprecated_3_0_0(tmpdir):
     logger = HDF5Logger(directory=str(tmpdir), buffer_length=5)
-    logger.open()
+    with pytest.warns(DeprecationWarning):
+        logger.open()
 
     logger.record([Packet()])
     assert len(logger._buffer['packets']) == 1
@@ -48,31 +70,75 @@ def test_flush(tmpdir):
     logger.record([Packet()])
     assert len(logger._buffer['packets']) == 0
 
-def test_close(tmpdir):
-    logger = HDF5Logger(directory=str(tmpdir))
-    logger.open()
+def test_flush(tmpdir):
+    logger = HDF5Logger(directory=str(tmpdir), buffer_length=5,
+            enabled=True)
+    logger.record([Packet()])
+    assert len(logger._buffer['packets']) == 1
+    logger.flush()
+    assert len(logger._buffer['packets']) == 0
+    logger.record([Packet()]*5)
+    assert len(logger._buffer['packets']) == 5
+    logger.record([Packet()])
+    assert len(logger._buffer['packets']) == 0
 
-    logger.close()
+def test_close_deprecated_3_0_0(tmpdir):
+    logger = HDF5Logger(directory=str(tmpdir))
+    with pytest.warns(DeprecationWarning):
+        logger.open()
+
+    with pytest.warns(DeprecationWarning):
+        logger.close()
     assert not logger.is_enabled()
-    assert not logger.is_open()
+    with pytest.warns(DeprecationWarning):
+        assert not logger.is_open()
 
-def test_record(tmpdir):
+def test_record_deprecated_3_0_0(tmpdir):
     logger = HDF5Logger(directory=str(tmpdir))
-    logger.open()
+    with pytest.warns(DeprecationWarning):
+        logger.open()
 
     logger.record([Packet()])
     assert len(logger._buffer['packets']) == 1
     logger.record([TimestampPacket(timestamp=123)])
     assert len(logger._buffer['packets']) == 2
 
+def test_record(tmpdir):
+    logger = HDF5Logger(directory=str(tmpdir), enabled=True)
+    logger.record([Packet()])
+    assert len(logger._buffer['packets']) == 1
+    logger.record([TimestampPacket(timestamp=123)])
+    assert len(logger._buffer['packets']) == 2
+
+@pytest.mark.filterwarnings("ignore:no IO object")
+def test_controller_write_capture_deprecated_3_0_0(tmpdir, chip):
+    controller = Controller()
+    controller.logger = HDF5Logger(directory=str(tmpdir), buffer_length=1)
+    with pytest.warns(DeprecationWarning):
+        controller.logger.open()
+    controller.chips[chip.chip_key] = chip
+    controller.write_configuration(chip.chip_key, 0)
+    packet = chip.get_configuration_packets(Packet.CONFIG_WRITE_PACKET)[0]
+    assert len(controller.logger._buffer['packets']) == 1
+
 @pytest.mark.filterwarnings("ignore:no IO object")
 def test_controller_write_capture(tmpdir, chip):
     controller = Controller()
     controller.logger = HDF5Logger(directory=str(tmpdir), buffer_length=1)
-    controller.logger.open()
+    controller.logger.enable()
     controller.chips[chip.chip_key] = chip
     controller.write_configuration(chip.chip_key, 0)
     packet = chip.get_configuration_packets(Packet.CONFIG_WRITE_PACKET)[0]
+    assert len(controller.logger._buffer['packets']) == 1
+
+def test_controller_read_capture_deprecated_3_0_0(tmpdir):
+    controller = Controller()
+    controller.io = FakeIO()
+    controller.io.queue.append(([Packet()], b'\x00\x00'))
+    controller.logger = HDF5Logger(directory=str(tmpdir), buffer_length=1)
+    with pytest.warns(DeprecationWarning):
+        controller.logger.open()
+    controller.run(0.1,'test')
     assert len(controller.logger._buffer['packets']) == 1
 
 def test_controller_read_capture(tmpdir):
@@ -80,6 +146,6 @@ def test_controller_read_capture(tmpdir):
     controller.io = FakeIO()
     controller.io.queue.append(([Packet()], b'\x00\x00'))
     controller.logger = HDF5Logger(directory=str(tmpdir), buffer_length=1)
-    controller.logger.open()
+    controller.logger.enable()
     controller.run(0.1,'test')
     assert len(controller.logger._buffer['packets']) == 1

--- a/test/test_stdout_logger.py
+++ b/test/test_stdout_logger.py
@@ -10,7 +10,8 @@ from larpix.logger.stdout_logger import StdoutLogger
 
 def test_enable():
     logger = StdoutLogger(buffer_length=1)
-    logger.open()
+    with pytest.warns(DeprecationWarning):
+        logger.open()
 
     logger.enable()
     assert logger.is_enabled()
@@ -19,7 +20,8 @@ def test_enable():
 
 def test_disable():
     logger = StdoutLogger()
-    logger.open()
+    with pytest.warns(DeprecationWarning):
+        logger.open()
 
     logger.disable()
     assert not logger.is_enabled()
@@ -28,14 +30,17 @@ def test_disable():
 
 def test_open():
     logger = StdoutLogger()
-    logger.open()
+    with pytest.warns(DeprecationWarning):
+        logger.open()
 
     assert logger.is_enabled()
-    assert logger.is_open()
+    with pytest.warns(DeprecationWarning):
+        assert logger.is_open()
 
 def test_flush():
     logger = StdoutLogger(buffer_length=5)
-    logger.open()
+    with pytest.warns(DeprecationWarning):
+        logger.open()
 
     logger.record(['test'])
     assert len(logger._buffer) == 1
@@ -48,15 +53,18 @@ def test_flush():
 
 def test_close():
     logger = StdoutLogger()
-    logger.open()
-
-    logger.close()
+    with pytest.warns(DeprecationWarning):
+        logger.open()
+    with pytest.warns(DeprecationWarning):
+        logger.close()
     assert not logger.is_enabled()
-    assert not logger.is_open()
+    with pytest.warns(DeprecationWarning):
+        assert not logger.is_open()
 
 def test_record():
     logger = StdoutLogger(buffer_length=1)
-    logger.open()
+    with pytest.warns(DeprecationWarning):
+        logger.open()
 
     logger.record(['test'])
     assert logger._buffer[0] == 'Record: test'
@@ -65,7 +73,8 @@ def test_record():
 def test_controller_write_capture(capfd, chip):
     controller = Controller()
     controller.logger = StdoutLogger(buffer_length=100)
-    controller.logger.open()
+    with pytest.warns(DeprecationWarning):
+        controller.logger.open()
     controller.chips[chip.chip_key] = chip
     controller.write_configuration(chip.chip_key, 0)
     packet = chip.get_configuration_packets(Packet.CONFIG_WRITE_PACKET)[0]
@@ -76,6 +85,7 @@ def test_controller_read_capture(capfd):
     controller.io = FakeIO()
     controller.io.queue.append(([Packet()], b'\x00\x00'))
     controller.logger = StdoutLogger(buffer_length=100)
-    controller.logger.open()
+    with pytest.warns(DeprecationWarning):
+        controller.logger.open()
     controller.run(0.1,'test')
     assert len(controller.logger._buffer) == 1

--- a/test/test_tutorial.py
+++ b/test/test_tutorial.py
@@ -11,7 +11,7 @@ def test_min_example(capsys):
     controller = Controller()
     controller.io = FakeIO()
     controller.logger = StdoutLogger(buffer_length=0)
-    controller.logger.open()
+    controller.logger.enable()
     chip1 = controller.add_chip('1-1-1')  # (access key)
     chip1.config.global_threshold = 25
     controller.write_configuration('1-1-1', 25) # chip key, register 25
@@ -32,7 +32,7 @@ def test_tutorial(capsys, tmpdir, temp_logfilename):
     controller = Controller()
     controller.io = FakeIO()
     controller.logger = StdoutLogger(buffer_length=0)
-    controller.logger.open()
+    controller.logger.enable()
 
 
     chip_key = '1-1-5'
@@ -131,8 +131,10 @@ def test_tutorial(capsys, tmpdir, temp_logfilename):
 
     from larpix.logger.h5_logger import HDF5Logger
     controller.logger = HDF5Logger(filename=temp_logfilename, directory=str(tmpdir), buffer_length=10000) # a filename of None uses the default filename formatting
-    controller.logger.open() # opens hdf5 file and starts tracking all communications
+    controller.logger.enable() # opens hdf5 file and starts tracking all communications
 
+    controller.logger = HDF5Logger(filename=temp_logfilename,
+            directory=str(tmpdir), enabled=True)
 
     controller.verify_configuration()
     controller.logger.flush()
@@ -144,7 +146,7 @@ def test_tutorial(capsys, tmpdir, temp_logfilename):
     controller.logger.is_enabled() # returns True if tracking
 
 
-    controller.logger.close()
+    controller.logger.disable()
 
 
     import h5py


### PR DESCRIPTION
In particular, the enable/disable/is_enabled logic, and the init method
are now implemented in Logger.

This also involves deprecating the open/close/is_open methods, which
now raise ``DeprecationWarning``s. These methods now just edit the
``_open`` instance attribute which is never referenced in any methods.
These methods and instance attribute will be removed in the next major
version.

Tests have been updated to both "deprecated" versions and normal
versions.

The tutorial has been updated to stop referencing the open and close
methods.

Fixes #156