### PR TITLE
Update internal data representation of Keys

### DIFF
--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -2056,6 +2056,12 @@ def test_key():
     with pytest.raises(ValueError):
         k = Key('256-0-0')
         pytest.fail('key value is not 1-byte')
+    with pytest.raises(ValueError):
+        k = Key(256,0,0)
+        pytest.fail('key value is not 1-byte')
+    with pytest.raises(TypeError):
+        k = Key(250,0,0,1)
+        pytest.fail('too many args')
 
     k = Key('1-2-3')
     with pytest.raises(ValueError):


### PR DESCRIPTION
Aims to address issue #175 . Bumps up chip key assignment to ~7-8us.
```python
In [1]: from larpix.larpix import Key, Packet                                   

In [2]: %timeit p = Packet(); p.chip_key=Key(1,2,3)                             
7.61 µs ± 87.5 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```