### PR TITLE
Optimize functions called in dataserver_message_decode

### DIFF
--- a/larpix/bitarrayhelper.py
+++ b/larpix/bitarrayhelper.py
@@ -5,13 +5,13 @@ A module with convenience functions for bitarray.
 from bitarray import bitarray
 
 def fromuint(val, nbits):
-    if isinstance(val, bitarray):
+    try:
+        if isinstance(nbits, slice):
+            nbits = abs(nbits.stop - nbits.start)
+        string = bin(val)[2:].zfill(nbits)
+        return bitarray(string)
+    except TypeError:
         return val
-    if isinstance(nbits, slice):
-        nbits = abs(nbits.stop - nbits.start)
-    bin_string = bin(val)[2:]
-    padding = '0' * (nbits - len(bin_string))
-    return bitarray(padding + bin_string)
 
 def touint(bits):
     bin_string = bits.to01()

--- a/larpix/io/multizmq_io.py
+++ b/larpix/io/multizmq_io.py
@@ -132,11 +132,10 @@ class MultiZMQ_IO(IO):
         io_channel = kwargs['io_chain']
         if io_channel in self._miso_map:
             io_channel = self._miso_map[io_channel]
-        return Key.from_dict(dict(
-                io_group = self._io_group_table.inv[kwargs['address']],
-                io_channel = io_channel,
-                chip_id = kwargs['chip_id']
-            ))
+        return Key(self._io_group_table.inv[kwargs['address']],
+                io_channel,
+                kwargs['chip_id']
+            )
 
     def decode(self, msgs, address, **kwargs):
         '''

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -1951,8 +1951,7 @@ class Packet(object):
             self.bits.frombytes(reversed_bytestream)
             # Get rid of the padding (now at the beginning of the
             # bitstream because of the reverse order)
-            self.bits.pop(0)
-            self.bits.pop(0)
+            self.bits = self.bits[2:]
         else:
             raise ValueError('Invalid number of bytes: %s' %
                     len(bytestream))
@@ -2094,8 +2093,10 @@ class Packet(object):
             return
         if isinstance(value, Key):
             self._chip_key = value
-        self._chip_key = Key(value)
-        self.chipid = self._chip_key.chip_id
+        else:
+            self._chip_key = Key(value)
+        if self.chipid != self._chip_key.chip_id:
+            self.chipid = self._chip_key.chip_id
 
     @property
     def packet_type(self):


### PR DESCRIPTION
Re: #179

This addresses a bottleneck in the DAQ pipeline where it takes a long time to decode messages received from the LArPix I/O Network board (aka Bern board). This speedup should be sufficient to process 100,000 messages (1 second's worth of data) in 0.7 seconds.

@peter-madigan can you test this to make sure it is in fact fast enough?