### PR TITLE
Add inheritances as an option for all configuration files

### DIFF
--- a/larpix/configs/__init__.py
+++ b/larpix/configs/__init__.py
@@ -11,13 +11,30 @@ def _load_and_verify(file, config_type=None):
         assert config_data['_config_type'] == config_type, "Invalid config type {}".format(config_data['_config_type'])
     return _load_inheritance(config_data)
 
+def _inherit_dict(d, other, config_type=None):
+    '''
+    Copies other and overwrites with values from d following inheritance rules
+    of the config_type
+
+    '''
+    combined_d = dict(other.items())
+    for key,val in d.items():
+        if isinstance(val, dict) and key in other:
+            combined_d[key] = _inherit_dict(val, other[key], config_type)
+        else:
+            combined_d[key] = val
+    return combined_d
+
 def _load_inheritance(config):
     '''
     Loads parent config files specified in the "_include" field of a
     configuration.
 
     All files must be of the same config type and are loaded in the order
-    specified in the list
+    specified in the list.
+
+    All fields of dict-like objects within the included fields will be inherited
+    recursively
 
     '''
 
@@ -33,9 +50,15 @@ def _load_inheritance(config):
     for included_file in config['_include']:
         inherited_config = load(included_file, config_type=config_type)
         for key,val in inherited_config.items():
-            base_config[key] = val
+            if isinstance(val, dict) and key in base_config:
+                base_config[key] = _inherit_dict(val, base_config[key], config_type)
+            else:
+                base_config[key] = val
     for key,val in config.items():
-        base_config[key] = val
+        if isinstance(val, dict) and key in base_config:
+            base_config[key] = _inherit_dict(val, base_config[key], config_type)
+        else:
+            base_config[key] = val
     return base_config
 
 def load(filename, config_type=None):
@@ -49,7 +72,9 @@ def load(filename, config_type=None):
     '''
     if os.path.isfile(filename):
         with open(filename, 'r') as f:
-            return _load_and_verify(f, config_type)
+            data = _load_and_verify(f, config_type)
+            print(data)
+            return data
     elif os.path.isfile(os.path.join(os.path.dirname(__file__), filename)):
         with open(os.path.join(os.path.dirname(__file__), filename), 'r') as f:
             return _load_and_verify(f, config_type)

--- a/larpix/configs/chip/__init__.py
+++ b/larpix/configs/chip/__init__.py
@@ -2,7 +2,12 @@
 This module contains chip configuration files. They are formatted as standard
 JSON files with the following fields: ``"_config_type"``, ``"class"``, and
 ``"register_values"``. The ``_config_type`` field should always be set to
-``"chip"`` and is used for validation when loading the configuration.
+``"chip"`` and is used for validation when loading the configuration. An
+optional ``"_include"`` field can be used to specify other configurations to
+inherit configuration values from. Configuration inheritance occurs in the order
+specified in the list so if a conflict is encountered, fields from a file later
+in the list will overwrite fields from a file earlier in the list.
+
 Additionally, the ``class`` field provides additional validation. There are two
 configuration classes: ``"Configuration_v1"`` and ``"Configuration_v2"``, each
 corresponding to its respective ``larpix.configuration`` class. Attempting to
@@ -16,6 +21,7 @@ file::
 
     {
         "_config_type": "chip",
+        "_include": [],
         "class": "Configuration_v2",
         "register_values": {
             "pixel_trim_dac": [16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16],

--- a/larpix/configs/controller/__init__.py
+++ b/larpix/configs/controller/__init__.py
@@ -2,11 +2,15 @@
 This module contains controller configuration files, used to specify the physical
 asics present and their network structure
 
+V2 Configuration
+----------------
+
 The v2 configuration file is a standard JSON file structured as follows:
 
 .. parsed-literal::
     {
         "_config_type": "controller",
+        "_include": [<optional list of files to inherit from>],
         "name": <string identifier for configuration ID, e.g. "pcb-3", or "acube-2x2">,
         "layout": <string identifier for layout version, e.g. "1.2.0">,
         "asic_version": 2,
@@ -138,8 +142,31 @@ network. These are the nodes that will be configured first when initializing a
 network (with the next nodes order of configuration determined via the mosi_us
 configuration). If not specified, the node is assumed to not be a root node.
 
+The top-level "_include" field can be used to specify files to inherit from.
+All fields of the configuration down to the "chips" array level can be inherited.
+A standard use for this would be to specify each hydra network for a given channel
+independently, and inherit from all of the files in a single configuration
+file. E.g.::
+
+    {
+        "_config_type": "controller",
+        "_include": [
+            "network-1-1.json",
+            "network-1-2.json",
+            "network-1-3.json",
+            "network-1-4.json",
+            "network-2-1.json",
+            "network-2-2.json",
+            "network-2-3.json",
+            "network-2-4.json"
+            ],
+        "name": "multi-io-group-network"
+        "layout": null
+    }
 
 
+V1 Configuration
+----------------
 
 The v1 configuration file is a standard JSON file structured as follows:
 

--- a/larpix/controller.py
+++ b/larpix/controller.py
@@ -320,9 +320,13 @@ class Controller(object):
             self.remove_chip(chip) # clear chips and network
         try:
             def inherit_values(child_dict, parent_dict, value_keys):
-                return dict([(key, child_dict[key])
-                        if key in child_dict else (key, parent_dict[key])
-                        for key in value_keys])
+                return_dict = dict()
+                for key in value_keys:
+                    if key in child_dict:
+                        return_dict[key] = child_dict[key]
+                    elif key in parent_dict:
+                        return_dict[key] = parent_dict[key]
+                return return_dict
 
             self.chips = OrderedDict()
             for io_group, group_spec in system_info['network'].items():
@@ -351,32 +355,44 @@ class Controller(object):
                         subnetwork = self.network[io_group][io_channel]
 
                         if 'miso_us' in chip_spec:
-                            for idx, uart in enumerate(chip_inherited_data['miso_us_uart_map']):
-                                link = (chip_id, chip_spec['miso_us'][idx])
-                                if link[1] is None:
-                                    continue
-                                self.add_network_link(io_group, io_channel, 'miso_us', link, uart)
+                            try:
+                                for idx, uart in enumerate(chip_inherited_data['miso_us_uart_map']):
+                                    link = (chip_id, chip_spec['miso_us'][idx])
+                                    if link[1] is None:
+                                        continue
+                                    self.add_network_link(io_group, io_channel, 'miso_us', link, uart)
+                            except KeyError:
+                                raise KeyError('miso_us_uart_map unspecified for {}-{}-{}'.format(io_group,io_channel,chip_id))
 
                         if 'miso_ds' in chip_spec:
-                            for idx, uart in enumerate(chip_inherited_data['miso_ds_uart_map']):
-                                link = (chip_id, chip_spec['miso_ds'][idx])
-                                if link[1] is None:
-                                    continue
-                                self.add_network_link(io_group, io_channel, 'miso_ds', link, uart)
+                            try:
+                                for idx, uart in enumerate(chip_inherited_data['miso_ds_uart_map']):
+                                    link = (chip_id, chip_spec['miso_ds'][idx])
+                                    if link[1] is None:
+                                        continue
+                                    self.add_network_link(io_group, io_channel, 'miso_ds', link, uart)
+                            except KeyError:
+                                raise KeyError('miso_ds_uart_map unspecified for {}-{}-{}'.format(io_group,io_channel,chip_id))
                         elif subnetwork['miso_us'].in_edges(chip_id):
-                            for link in subnetwork['miso_us'].in_edges(chip_id):
-                                other_chip_id = link[0]
-                                other_spec = [spec for spec in channel_spec['chips'] if spec['chip_id'] == other_chip_id][0]
-                                uart = chip_inherited_data['miso_ds_uart_map'][other_spec['miso_us'].index(chip_id)]
-                                link = (chip_id, other_chip_id)
-                                self.add_network_link(io_group, io_channel, 'miso_ds', link, uart)
+                            try:
+                                for link in subnetwork['miso_us'].in_edges(chip_id):
+                                    other_chip_id = link[0]
+                                    other_spec = [spec for spec in channel_spec['chips'] if spec['chip_id'] == other_chip_id][0]
+                                    uart = chip_inherited_data['miso_ds_uart_map'][other_spec['miso_us'].index(chip_id)]
+                                    link = (chip_id, other_chip_id)
+                                    self.add_network_link(io_group, io_channel, 'miso_ds', link, uart)
+                            except KeyError:
+                                raise KeyError('miso_ds_uart_map unspecified for {}-{}-{}'.format(io_group,io_channel,chip_id))
 
                         if 'mosi' in chip_spec:
-                            for idx, uart in enumerate(chip_inherited_data['mosi_uart_map']):
-                                link = (chip_id, chip_spec['miso_us'][idx])
-                                if link[1] is None:
-                                    continue
-                                self.add_network_link(io_group, io_channel, 'mosi', link, uart)
+                            try:
+                                for idx, uart in enumerate(chip_inherited_data['mosi_uart_map']):
+                                    link = (chip_id, chip_spec['miso_us'][idx])
+                                    if link[1] is None:
+                                        continue
+                                    self.add_network_link(io_group, io_channel, 'mosi', link, uart)
+                            except KeyError:
+                                raise KeyError('mosi_uart_map unspecified for {}-{}-{}'.format(io_group,io_channel,chip_id))
                         else:
                             for link in subnetwork['miso_us'].in_edges():
                                 self.add_network_link(io_group, io_channel, 'mosi', link[::-1], subnetwork['miso_us'].edges[link]['uart'])

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -2,6 +2,7 @@ from larpix import Configuration_v2
 from bitarray import bitarray
 import larpix.bitarrayhelper as bah
 from larpix import configs
+import json
 
 def test_v2_conf_all_registers():
     default_filename = 'chip/default_v2.json'
@@ -9,7 +10,7 @@ def test_v2_conf_all_registers():
 
     c = Configuration_v2()
     # check that all registers are in the configuration file
-    assert all([register_name in data['register_values'].keys() for register_name in c.register_names])
+    assert set(data['register_values'].keys()) == set(c.register_names)
     for register in c.register_names:
         print('testing {}'.format(register))
         config_value = data['register_values'][register]
@@ -193,6 +194,25 @@ def test_compare():
     c = Configuration_v2()
     c.threshold_global = 121
     assert c.compare(other) == {'threshold_global': (121, 255)}
+
+def test_load_inheritance(tmpdir):
+    filename = 'test.json'
+    c = Configuration_v2()
+    with open(tmpdir.join(filename),'w') as of:
+        config = {
+            "_config_type": "chip",
+            "_include": ["chip/default_v2.json"],
+            "class": "Configuration_v2",
+            "register_values": {
+                "pixel_trim_dac": [0, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16],
+                "threshold_global": 0
+            }
+        }
+        json.dump(config,of)
+    c.load(tmpdir.join(filename))
+    assert c.pixel_trim_dac[0] == 0
+    assert c.threshold_global == 0
+    assert c.csa_gain == 1
 
 def test_get_nondefault_registers():
     c = Configuration_v2()

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -198,7 +198,7 @@ def test_compare():
 def test_load_inheritance(tmpdir):
     filename = 'test.json'
     c = Configuration_v2()
-    with open(tmpdir.join(filename),'w') as of:
+    with open(str(tmpdir.join(filename)),'w') as of:
         config = {
             "_config_type": "chip",
             "_include": ["chip/default_v2.json"],

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -209,7 +209,7 @@ def test_load_inheritance(tmpdir):
             }
         }
         json.dump(config,of)
-    c.load(tmpdir.join(filename))
+    c.load(str(tmpdir.join(filename)))
     assert c.pixel_trim_dac[0] == 0
     assert c.threshold_global == 0
     assert c.csa_gain == 1

--- a/test/test_configuration_files.py
+++ b/test/test_configuration_files.py
@@ -67,16 +67,19 @@ def test_config_inheritance_complex(tmpfile, other_tmpfile):
     write_json(tmpfile,
         _config_type='test',
         _include=[other_tmpfile],
-        dict_field={'base':True},
+        dict_field={'base':True,'dict':{'overwrite':True}},
         list_field=[1]
         )
     write_json(other_tmpfile,
         _config_type='test',
-        dict_field={'inherited':True,'base':False},
+        dict_field={'inherited':True,'base':False,'dict':{'test':True,'overwrite':False}},
+        list_field=[2]
         )
     config = configs.load(tmpfile)
     assert config['dict_field']['base']
     assert config['dict_field']['inherited']
+    assert config['dict_field']['dict']['test']
+    assert config['dict_field']['dict']['overwrite']
     assert config['list_field'] == [1]
 
 def test_config_inheritance_order(tmpfile, other_tmpfile, other_other_tmpfile):

--- a/test/test_configuration_files.py
+++ b/test/test_configuration_files.py
@@ -1,0 +1,75 @@
+import pytest
+import json
+from larpix import configs
+
+@pytest.fixture
+def tmpfile(tmpdir):
+    return str(tmpdir.join('test_conf.json'))
+
+@pytest.fixture
+def other_tmpfile(tmpdir):
+    return str(tmpdir.join('other_test_conf.json'))
+
+def write_json(file, **kwargs):
+    with open(file,'w') as of:
+        json.dump(kwargs, of)
+
+def test_config_read(tmpfile):
+    write_json(tmpfile,
+        _config_type='test',
+        test=True
+        )
+
+    config = configs.load(tmpfile, 'test')
+    assert config['_config_type'] == 'test'
+    assert config['test']
+
+    config = configs.load(tmpfile)
+    assert config['_config_type'] == 'test'
+    assert config['test']
+
+    with pytest.raises(AssertionError):
+        config = configs.load(tmpfile, 'not_test')
+
+def test_config_inheritance(tmpfile, other_tmpfile):
+    write_json(tmpfile,
+        _config_type='test',
+        _include=[other_tmpfile],
+        test=True
+        )
+    write_json(other_tmpfile,
+        _config_type='test',
+        inherited=True
+        )
+
+    config = configs.load(tmpfile, 'test')
+    assert config['inherited']
+    assert config['test']
+
+    write_json(tmpfile,
+        _config_type='test',
+        _include=[other_tmpfile],
+        test=True
+        )
+    write_json(other_tmpfile,
+        _config_type='test',
+        test=False
+        )
+
+    config = configs.load(tmpfile, 'test')
+    assert config['test']
+
+def test_config_inheritance_error(tmpfile, other_tmpfile):
+    write_json(tmpfile,
+        _config_type='test',
+        _include=[other_tmpfile]
+        )
+    write_json(other_tmpfile,
+        _config_type='not_test'
+        )
+
+    with pytest.raises(AssertionError):
+        config = configs.load(tmpfile, 'test')
+
+    with pytest.raises(AssertionError):
+        config = configs.load(tmpfile)


### PR DESCRIPTION
Adds the optional "_include" field to configuration files which loads fields included specified files. Verifies that configuration types ("_config_type") of inherited files matches.