### PR TITLE
Implement network traversal in controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,13 @@ controller.init_network(1,1,2) # configures only chip 2
 controller.init_network(1,1,3) # configures only chip 3
 ```
 
-But this requires initializing the chips in the proper order.
+But this requires initializing the chips in the proper order. You can get the
+chip keys in order of their depth within the network via
+
+```python
+controller.get_network_keys(1,1) # gets a list of chip keys starting at the root node and descending
+controller.get_network_keys(1,1,root_first_traversal=False) # get list of chip keys starting at deepest chips and ascending
+```
 
 
 ### Adjust the configuration of the LArPix Chips

--- a/larpix/controller.py
+++ b/larpix/controller.py
@@ -107,6 +107,12 @@ class Controller(object):
         controller.init_network(1,1) # configure the 1-1 network
         controller.reset_network(1,1) # revert the 1-1 network to it's original state
 
+    In the event that you need to access the chip keys of a network in the order
+    of their depth within the network, use::
+
+        controller.get_network_keys(1,1) # get a list of chip keys starting with the root node and descending into the network
+        controller.get_network_keys(1,1,root_first_traversal=False) # get a list of chip keys starting with the chips deepest in the network and ascending
+
     You may also specify a network configuration file and use this to create all
     of the necessary network links and chips. See
     <https://larpix-control.readthedocs.io/en/stable/api/configs/controller.html>
@@ -261,6 +267,34 @@ class Controller(object):
         else:
             for name in network_names:
                 self.network[io_group][io_channel][name].add_node(chip_id, root=root)
+
+    def get_network_keys(self, io_group, io_channel, root_first_traversal=True):
+        '''
+        Returns a list of chip keys in order of depth within the miso_us network
+
+        :param io_group: io group of network
+
+        :param io_channel: io channel of network
+
+        :param root_first_traversal: ``True`` to traverse network starting from root nodes then increasing in network depth, ``False`` to traverse network starting from nodes furthest from root nodes and then decreasing in network depth
+
+        '''
+        subnetwork = self.network[io_group][io_channel]['miso_us']
+        ordered_keys = []
+
+        chip_ids = [chip_id for chip_id in subnetwork.nodes() if subnetwork.nodes[chip_id]['root']]
+
+        collected_chips = set(chip_ids)
+
+        while chip_ids:
+            for chip_id in chip_ids:
+                if isinstance(chip_id, int):
+                    ordered_keys.append(Key(io_group, io_channel, chip_id))
+                collected_chips.add(chip_id)
+            chip_ids = [link[1] for link in subnetwork.out_edges(chip_ids) if not link[1] in collected_chips]
+        if root_first_traversal:
+            return ordered_keys
+        return ordered_keys[::-1]
 
     def _create_network(self, io_group, io_channel, network_names):
         '''
@@ -541,14 +575,9 @@ class Controller(object):
         '''
         subnetwork = self.network[io_group][io_channel]
         if chip_id is None:
-            chip_ids = [chip_id for chip_id in subnetwork['miso_us'].nodes() if subnetwork['miso_us'].nodes[chip_id]['root']]
-            configured_chips = set(chip_ids)
-
-            while chip_ids:
-                for chip_id in chip_ids:
-                    self.init_network(io_group, io_channel, chip_id=chip_id)
-                    configured_chips.add(chip_id)
-                chip_ids = [link[1] for link in subnetwork['miso_us'].out_edges(chip_ids) if not link[1] in configured_chips]
+            chip_keys = self.get_network_keys(io_group, io_channel, root_first_traversal=True)
+            for chip_key in chip_keys:
+                self.init_network(io_group, io_channel, chip_id=chip_key.chip_id)
             return
 
         packets = []
@@ -606,14 +635,9 @@ class Controller(object):
         '''
         subnetwork = self.network[io_group][io_channel]
         if chip_id is None:
-            chip_ids = [chip_id for chip_id in subnetwork['miso_us'].nodes() if not subnetwork['miso_us'].out_edges(chip_id)]
-            configured_chips = set(chip_ids)
-
-            while chip_ids:
-                for chip_id in chip_ids:
-                    self.reset_network(io_group, io_channel, chip_id=chip_id)
-                    configured_chips.add(chip_id)
-                chip_ids = [link[0] for link in subnetwork['miso_us'].in_edges(chip_ids) if not link[0] in configured_chips]
+            chip_keys = self.get_network_keys(io_group, io_channel, root_first_traversal=False)
+            for chip_key in chip_keys:
+                self.reset_network(io_group, io_channel, chip_id=chip_key.chip_id)
             return
 
         packets = []

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -233,3 +233,19 @@ def test_controller_reset(network_controller):
         assert c[chip_key].config.chip_id == 1
         assert c[chip_key].config.enable_miso_downstream == [0,0,0,0]
         assert c[chip_key].config.enable_mosi == [1,1,1,1]
+
+def test_controller_network_traversal(network_controller):
+    c = network_controller
+
+    keys = c.get_network_keys(1,1,root_first_traversal=True)
+    assert len(keys) == 4
+    assert keys[0] == '1-1-2'
+    assert set(keys[1:3]) == set(['1-1-3','1-1-12'])
+    assert keys[3] == '1-1-13'
+
+    keys = c.get_network_keys(1,1,root_first_traversal=False)
+    assert len(keys) == 4
+    assert keys[0] == '1-1-13'
+    assert set(keys[1:3]) == set(['1-1-3','1-1-12'])
+    assert keys[3] == '1-1-2'
+

--- a/test/test_tutorial.py
+++ b/test/test_tutorial.py
@@ -73,6 +73,9 @@ def test_tutorial(capsys, tmpdir, temp_logfilename):
     controller.init_network(1,1,2) # configures only chip 2
     controller.init_network(1,1,3) # configures only chip 3
 
+    assert isinstance(controller.get_network_keys(1,1), list) # gets a list of chip keys starting at the root node and descending
+    assert isinstance(controller.get_network_keys(1,1,root_first_traversal=False), list) # get list of chip keys starting at deepest chips and ascending
+
 
     chip5.config.threshold_global = 35  # entire register = 1 number
     chip5.config.enable_periodic_reset = 1  # one bit as part of a register


### PR DESCRIPTION
Allows access to a list of chip keys sorted by their depth within the network structure -- useful for things like modifying the uart speed, etc. where network communications could be broken by the configuration.

Moved from PR #199 