### PR TITLE
Multi-thread HDF5Logger file access

### DIFF
--- a/larpix/logger/h5_logger.py
+++ b/larpix/logger/h5_logger.py
@@ -1,7 +1,11 @@
 import time
 import os
 import threading
-import queue
+import sys
+if sys.version_info[0] >= 3:
+    from queue import Queue
+else:
+    from Queue import Queue
 
 import numpy as np
 import h5py
@@ -52,7 +56,7 @@ class HDF5Logger(Logger):
         self.buffer_length = buffer_length
 
         self._buffer = {'packets': []}
-        self._worker_queue = queue.Queue()
+        self._worker_queue = Queue()
         self._worker = None
         if not self.filename:
             self.filename = self._default_filename()
@@ -112,7 +116,7 @@ class HDF5Logger(Logger):
         self.flush(block=False)
 
     def flush(self, block=True):
-        self._worker_queue.put(self._buffer['packets'].copy())
+        self._worker_queue.put(self._buffer['packets'])
         if self._worker is None:
             self._launch_worker()
         if block:

--- a/larpix/logger/h5_logger.py
+++ b/larpix/logger/h5_logger.py
@@ -3,9 +3,9 @@ import os
 import threading
 import sys
 if sys.version_info[0] >= 3:
-    from queue import Queue
+    from queue import Queue, Empty
 else:
-    from Queue import Queue
+    from Queue import Queue, Empty
 
 import numpy as np
 import h5py
@@ -133,8 +133,11 @@ class HDF5Logger(Logger):
                 packets = self._worker_queue.get(timeout=1)
                 to_file(self.filename, packets, version=self.version)
                 self._worker_queue.task_done()
-        except:
+        except Empty:
             pass
+        except:
+            print('HDF5Logger IO thread error!')
+            raise
         finally:
             self._worker = None
 


### PR DESCRIPTION
This PR multi-threads the HDF5Logger file access so that calls to `HDF5Logger.record` no longer block while waiting for file access. This should fix the issue we found with continuous operation at high data rates (particularly on the raspberry pi).