### PR TITLE
Feature/recursive verify registers

### DIFF
--- a/larpix/controller.py
+++ b/larpix/controller.py
@@ -1209,7 +1209,7 @@ class Controller(object):
                 del configuration_data[chip_key]
 
         if not return_value and n != 1:
-            retry_chip_key_register_pairs = [(key,value) for key,value in configuration_data.items() if value[-1] is None]
+            retry_chip_key_register_pairs = [(key,registre) for key,value in configuration_data.items() for register in value if value[register][-1] is None]
             if len(retry_chip_key_register_pairs):
                 retry_return_value, retry_configuration_data = self.verify_registers(
                     retry_chip_key_register_pairs,

--- a/larpix/controller.py
+++ b/larpix/controller.py
@@ -1219,6 +1219,9 @@ class Controller(object):
                     )
                 for chip_key in retry_configuration_data.keys():
                     configuration_data[chip_key].update(retry_configuration_data[chip_key])
+                for chip_key,register in retry_chip_key_register_pairs:
+                    if chip_key not in retry_configuration_data or register not in retry_configuration_data[chip_key]:
+                        del configuration_data[chip_key][register]
                 return_value = all([
                     configuration_data[chip_key][register][0] == configuration_data[chip_key][register][1]
                     for chip_key in configuration_data

--- a/larpix/controller.py
+++ b/larpix/controller.py
@@ -1209,7 +1209,7 @@ class Controller(object):
                 del configuration_data[chip_key]
 
         if not return_value and n != 1:
-            retry_chip_key_register_pairs = [(key,registre) for key,value in configuration_data.items() for register in value if value[register][-1] is None]
+            retry_chip_key_register_pairs = [(key,register) for key,value in configuration_data.items() for register in value if value[register][-1] is None]
             if len(retry_chip_key_register_pairs):
                 retry_return_value, retry_configuration_data = self.verify_registers(
                     retry_chip_key_register_pairs,

--- a/larpix/controller.py
+++ b/larpix/controller.py
@@ -1226,7 +1226,7 @@ class Controller(object):
                     ])
         return (return_value, configuration_data)
 
-    def verify_configuration(self, chip_keys=None, timeout=1):
+    def verify_configuration(self, chip_keys=None, timeout=1, connection_delay=0.02, n=1):
         '''
         Read chip configuration from specified chip(s) and return ``True`` if the
         read chip configuration matches the current configuration stored in chip instance.
@@ -1240,6 +1240,8 @@ class Controller(object):
 
         :param timeout: how long to wait for response in seconds
 
+        :param n: set recursion limit for rechecking non-responding registers
+
         :returns: 2-``tuple`` with same format as ``controller.verify_registers``
 
         '''
@@ -1248,7 +1250,7 @@ class Controller(object):
         if isinstance(chip_keys,(str,Key)):
             chip_keys = [chip_keys]
         chip_key_register_pairs = [(chip_key, range(self[chip_key].config.num_registers)) for chip_key in chip_keys]
-        return self.verify_registers(chip_key_register_pairs, timeout=timeout)
+        return self.verify_registers(chip_key_register_pairs, timeout=timeout, connection_delay=connection_delay, n=n)
 
     def verify_network(self, chip_keys=None, timeout=1):
         '''


### PR DESCRIPTION
Adds the keyword argument `n` to `verify_registers` and `verify_configuration` to recursively check any registers that do not respond.