### PR TITLE
Feature/hdf5 performance optimization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
     - "3.6"
-    - "2.7"
 install:
     - pip install .
 script: pytest

--- a/docs/api/format/index.rst
+++ b/docs/api/format/index.rst
@@ -7,6 +7,7 @@ The data formats used for LArPix are:
    :maxdepth: 2
 
    hdf5format
+   rawhdf5format
    message_format
 
    pacman_msg_format

--- a/docs/api/format/rawhdf5format.rst
+++ b/docs/api/format/rawhdf5format.rst
@@ -1,0 +1,11 @@
+LArPix raw HDF5 Format
+======================
+
+.. automodule:: larpix.format.rawhdf5format
+   :no-members:
+   :members: to_rawfile, from_rawfile, len_rawfile
+
+   .. autodata:: larpix.format.rawhdf5format.latest_version
+   .. autodata:: larpix.format.rawhdf5format.dataset_dtypes
+     :annotation:
+

--- a/larpix/format/hdf5format.py
+++ b/larpix/format/hdf5format.py
@@ -692,12 +692,13 @@ def _format_packets_packet_v2_3(pkt, version='2.3', dset='packets', *args, **kwa
     encoded_packet = [0]*len(dtypes[version][dset])
     i = 0
     for value_name, value_type in dtypes[version][dset]:
-        if hasattr(pkt, value_name):
+        try:
             encoded_packet[i] = getattr(pkt, value_name)
-        elif value_name == 'valid_parity' and hasattr(pkt, 'has_valid_parity'):
-            encoded_packet[i] = pkt.has_valid_parity()
-        elif value_type[0] == 'S': # string default
-            encoded_packet[i] = ''
+        except AttributeError:
+            if value_name == 'valid_parity' and hasattr(pkt, 'has_valid_parity'):
+                encoded_packet[i] = pkt.has_valid_parity()
+            elif value_type[0] == 'S': # string default
+                encoded_packet[i] = ''
         i += 1
     if pkt.packet_type == 6: # sync packets
         encoded_packet[dtype_property_index_lookup[version]['packets']['trigger_type']] = _uint8_struct.unpack(pkt.sync_type)[0]

--- a/larpix/format/rawhdf5format.py
+++ b/larpix/format/rawhdf5format.py
@@ -69,18 +69,18 @@ _latest_version = '0.0'
 
 dataset_dtypes = {
     '0.0': {
-        'msgs': h5py.string_dtype('utf-8'),
+        'msgs': h5py.vlen_dtype(np.dtype('u1')),
         'io_groups': np.dtype('u1')
     }
 }
 def _store_msgs_v0_0(msgs, version):
-    return np.array(msgs, dtype=dataset_dtypes[version]['msgs'])
+    return np.array([np.array(list(msg), dtype=np.dtype('u1')) for msg in msgs], dtype=dataset_dtypes[version]['msgs'])
 
 def _store_io_groups_v0_0(io_groups, version):
     return np.array(io_groups, dtype=dataset_dtypes[version]['io_groups'])
 
 def _parse_msgs_v0_0(msgs, version):
-    return [bytes(msg,'utf-8') for msg in msgs]
+    return [bytes(msg) for msg in msgs]
 
 def _parse_io_groups_v0_0(io_groups, version):
     return list(io_groups.astype(int))

--- a/larpix/format/rawhdf5format.py
+++ b/larpix/format/rawhdf5format.py
@@ -1,0 +1,258 @@
+'''
+This is an alternative hdf5 format that allows for much faster conversion to
+file than the ``larpix.format.hdf5format`` at the expense of human readability.
+To use, pass a list of bytestring messages into the ``to_rawfile()`` method::
+
+    msgs = [b'this is a test message', b'this is a different message']
+    to_rawfile('raw.h5', msgs)
+
+To access the data in the file, the inverse method ``from_rawfile()`` is used::
+
+    rd = from_rawfile('raw.h5')
+    rd['msgs'] # [b'this is a test message', b'this is a different message']
+
+Message may be recieved from multiple ``io_group`` sources, in this case, a
+per-message ``io_group`` can be specified as a list of integers of the same
+length as the ``msgs`` list and passed into the file at the same time::
+
+    msgs = [b'message from 1', b'message from 2']
+    io_groups = [1, 2]
+    to_rawfile('raw.h5', msgs=msgs, io_groups=io_groups)
+
+    rd = from_rawfile('raw.h5')
+    rd['msgs'] # [b'message from 1', b'message from 2']
+    rd['io_groups'] # [1, 2]
+
+This format was created with a specific application in mind - provide a
+temporary but fast persistent file format for PACMAN messages. When used in this
+case, to convert to the standard ``larpix.format.hdf5format``::
+
+    from larpix.format.pacman_msg_format import parse
+    from larpix.format.hdf5format import to_file
+
+    rd = from_rawfile('raw.h5')
+    pkts = list()
+    for io_group,msg in zip(rd['io_group'], rd['msgs']):
+        pkts.extend(parse(msg, io_group=io_group))
+    to_file('new_filename.h5', packet_list=pkts)
+
+Metadata (v0.0)
+---------------
+The group ``meta`` contains file-level information stored as attributes:
+
+    - ``created``: float, unix timestamp since the 1970 epoch in seconds
+        indicating when file was first created
+
+    - ``modified``: float, unix timestamp since the 1970 epoch in seconds
+        indicating when the file was last written to
+
+    - ``version``: str, a string representing the file version, formatted as
+        ``'major.minor'``
+
+Datasets (v0.0)
+---------------
+The hdf5 format contains two datasets ``msgs`` and ``io_groups``. The ``msgs``
+dataset contains 1 row for each bytestring message stored as a variable length
+string. The ``io_groups`` dataset contains 1 row for each bytestring message and
+contains the ``io_group`` associated with the message at the same row index. This
+allows for storing data from multiple ``io_group`` sources, i.e. two PACMAN cards
+in the same experiment.
+
+'''
+import time
+import warnings
+
+import h5py
+import numpy as np
+
+_latest_version = '0.0'
+
+dataset_dtypes = {
+    '0.0': {
+        'msgs': h5py.string_dtype('utf-8'),
+        'io_groups': np.dtype('u1')
+    }
+}
+def _store_msgs_v0_0(msgs, version):
+    return np.array(msgs, dtype=dataset_dtypes[version]['msgs'])
+
+def _store_io_groups_v0_0(io_groups, version):
+    return np.array(io_groups, dtype=dataset_dtypes[version]['io_groups'])
+
+def _parse_msgs_v0_0(msgs, version):
+    return [bytes(msg,'utf-8') for msg in msgs]
+
+def _parse_io_groups_v0_0(io_groups, version):
+    return list(io_groups.astype(int))
+
+def _store_msgs(msgs, version):
+    '''
+    A version-safe way to put messages into the dataset
+
+    :param msgs: an iterable of PACMAN messages to convert
+
+    :param version: version string
+
+    :returns: a numpy array, 1 row for each msg
+
+    '''
+    return _store_msgs_v0_0(msgs, version)
+
+def _store_io_groups(io_groups, version):
+    '''
+    A version-safe way to put io_groups into the dataset
+
+    :param msgs: an iterable of io_groups to convert to a numpy array
+
+    :param version: version string
+
+    :returns: a numpy array, 1 row for each io_group
+
+    '''
+    return _store_io_groups_v0_0(io_groups, version)
+
+def _parse_msgs(msgs, version):
+    '''
+    A version-safe conversion of numpy array void objects into PACMAN message byte strings
+
+    :param msgs: a list of void-type numpy arrays
+
+    :param version: version string
+
+    :returns: list of PACMAN message byte strings, 1 for each row in data
+    '''
+    return _parse_msgs_v0_0(msgs, version)
+
+def _parse_io_groups(io_groups, version):
+    '''
+    A version-safe conversion of io_groups numpy array to an io_groups list
+
+    :param msgs: an io_groups array to convert to a list of io_groups
+
+    :param version: version string
+
+    :returns: list of io_groups, 1 for each row in data
+    '''
+    return _parse_io_groups_v0_0(io_groups, version)
+
+def to_rawfile(filename, msgs=None, version=None, io_groups=None):
+    '''
+    Write a list of bytestring messages to an hdf5 file. If the file exists,
+    the messages will appended to the end of the dataset.
+
+    :param filename: desired filename for the file to write or update
+
+    :param msgs: iterable of variable-length bytestrings to write to the file, if None specified, will only create file and update metadata
+
+    :param version: a string of major.minor version desired, if None specified, will use the latest file format version (if new file) or version in file (if updating an existing file)
+
+    :param io_groups: iterable of io_groups to associate with each message, if None specified, will use a default value of 0 for each message
+
+    '''
+    now = time.time()
+    with h5py.File(filename, 'a', libver='latest') as f:
+        if 'meta' not in f.keys():
+            # new file
+            version = _latest_version if version is None else version
+            f.create_group('meta')
+            f['meta'].attrs['version'] = version
+            f['meta'].attrs['created'] = now
+            f['meta'].attrs['modified'] = now
+
+            # get current position in file
+            curr_idx = 0
+
+            # create datasets
+            f.create_dataset('msgs', shape=(0,), maxshape=(None,), compression='gzip', dtype=dataset_dtypes[version]['msgs'])
+            f.create_dataset('io_groups', shape=(0,), maxshape=(None,), compression='gzip', dtype=dataset_dtypes[version]['io_groups'])
+
+            f.swmr_mode = True
+        else:
+            # existing file
+            file_version = f['meta'].attrs['version']
+            assert (file_version == version) or (version is None), 'Version mismatch! file: {}, requested: {}'.format(file_version, version)
+            version = file_version
+
+            f.swmr_mode = True
+
+            f['meta'].attrs['modified'] = now
+
+        io_groups = io_groups if io_groups is not None else np.zeros(len(msgs))
+        assert len(io_groups) == len(msgs), 'Data length mismatch! msgs is length {}, but io_groups is length {}'.format(len(msgs),len(io_groups))
+
+        # resize datasets
+        curr_idx = len(f['msgs'])
+        f['msgs'].resize((curr_idx+len(msgs),))
+        f['io_groups'].resize((curr_idx+len(io_groups),))
+
+        # store in file
+        msgs_array = _store_msgs(
+            msgs,
+            version=version
+            )
+        io_groups_array = _store_io_groups(
+            io_groups,
+            version=version
+            )
+
+        f['msgs'][curr_idx:curr_idx + len(msgs_array)] = msgs_array
+        f['io_groups'][curr_idx:curr_idx + len(io_groups_array)] = io_groups_array
+
+        # flush
+        f['msgs'].flush()
+        f['io_groups'].flush()
+
+def from_rawfile(filename, version=None, start=None, end=None, attempts=10):
+    '''
+    Read a chunk of bytestring messages from an existing file
+
+    :param filename: filename to read bytestrings from
+
+    :param version: required version compatibility, if None specified, uses the version stored in the file metadata
+
+    :param start: index for the start position when reading from the file, >=0, default=0, if a value less than 0 is specified, data is read from the beginning of the file
+
+    :param end: index for the end position when reading from the file, <= len(data), default=len(data), if a value less than the length of the data in the file, data is read until the end of the file
+
+    :param attempts: a parameter only relevant if file is being actively written to, specifies number of refreshes to try if a synchronized state between the msgs and io_groups datasets is not achieved
+
+    :returns: dict with keys for 'created', 'modified', and 'version' metadata, along with the 'msgs': a list of bystrings and 'io_groups': a list of integers
+
+    '''
+    with h5py.File(filename, 'r', swmr=True, libver='latest') as f:
+        # fetch metadata
+        created = f['meta'].attrs['created']
+        modified = f['meta'].attrs['modified']
+        file_version = f['meta'].attrs['version']
+        version_major = file_version.split('.')[0]
+        assert (version is None) or (file_version >= version and version_major == version.split('.')[0]), 'Incompatible version mismatch! file: {}, requested: {}'.format(file_version, version)
+        version_minor = min(file_version.split('.')[-1], version.split('.')[-1]) if version is not None else file_version.split('.')[-1]
+        version = '{}.{}'.format(version_major,version_minor)
+
+        # check to make sure that the msgs and io_groups dsets are synchronized
+        success = False
+        for _ in range(attempts):
+            f['msgs'].id.refresh()
+            f['io_groups'].id.refresh()
+            if len(f['msgs']) == len(f['io_groups']):
+                success = True
+                break
+        if not success:
+            warnings.RuntimeWarning('Could not achieve a stable file state after {} attempts! Data may be weird...'.format(attempts))
+
+        # define chunk of data to load
+        start = max(start,0) if start is not None else 0
+        end = min(end,len(f['msgs'])) if end is not None else len(f['msgs'])
+        assert start <= end, 'Invalid chunk specification! (start={}, end={})'.format(start, end)
+
+        # get data from file
+        msgs = _parse_msgs(f['msgs'][start:end], version)
+        io_groups = _parse_io_groups(f['io_groups'][start:end], version)
+
+    return dict(
+        created=created,
+        modified=modified,
+        version=version,
+        msgs=msgs,
+        io_groups=io_groups
+        )

--- a/larpix/format/rawhdf5format.py
+++ b/larpix/format/rawhdf5format.py
@@ -69,12 +69,12 @@ _latest_version = '0.0'
 
 dataset_dtypes = {
     '0.0': {
-        'msgs': h5py.vlen_dtype(np.dtype('u1')),
+        'msgs': h5py.vlen_dtype(np.dtype('u8')),
         'io_groups': np.dtype('u1')
     }
 }
 def _store_msgs_v0_0(msgs, version):
-    return np.array([np.array(list(msg), dtype=np.dtype('u1')) for msg in msgs], dtype=dataset_dtypes[version]['msgs'])
+    return np.array([np.array([msg], dtype=np.void).view('u8') for msg in msgs], dtype=dataset_dtypes[version]['msgs'])
 
 def _store_io_groups_v0_0(io_groups, version):
     return np.array(io_groups, dtype=dataset_dtypes[version]['io_groups'])

--- a/larpix/io/pacman_io.py
+++ b/larpix/io/pacman_io.py
@@ -4,7 +4,11 @@ import bidict
 import time
 from collections import defaultdict
 import multiprocessing
-import queue
+import sys
+if sys.version_info[0] >= 3:
+    from queue import Empty
+else:
+    from Queue import Empty
 import os
 
 from larpix.io import IO
@@ -280,7 +284,7 @@ class PACMAN_IO(IO):
                     new_msgs, new_io_groups = queue_.get(False)
                     msgs.extend(new_msgs)
                     io_groups.extend(new_io_groups)
-                except queue.Empty:
+                except Empty:
                     break
             if len(msgs):
                 rawhdf5format.to_rawfile(filename, msgs=msgs, io_groups=io_groups)

--- a/larpix/packet/packet_v2.py
+++ b/larpix/packet/packet_v2.py
@@ -3,6 +3,30 @@ from bitarray import bitarray
 from .. import bitarrayhelper as bah
 from ..key import Key
 
+def _clears_cached_int(property):
+    '''
+    Modify a property so that it deletes the cached `_int` attribute, if it
+    exists
+
+    '''
+    def new_property(self, value):
+        if hasattr(self, '_int'):
+            del self._int
+        return property(self,value)
+    return new_property
+
+def _clears_cached_chip_key(property):
+    '''
+    Modify a property so that it deletes the cached `_chip_key` attribute, if it
+    exists
+
+    '''
+    def new_property(self, value):
+        if hasattr(self, '_chip_key'):
+            del self._chip_key
+        return property(self,value)
+    return new_property
+
 class Packet_v2(object):
     '''
     Representation of a 64 bit LArPix v2 (or LightPix v1) UART data packet.
@@ -221,6 +245,11 @@ class Packet_v2(object):
             else:
                 setattr(self, key, value)
 
+    def as_int(self):
+        if not hasattr(self, '_int'):
+            self._int = bah.touint(self.bits, endian=self.endian)
+        return self._int
+
     @property
     def chip_key(self):
         ''''''
@@ -232,10 +261,9 @@ class Packet_v2(object):
         return self._chip_key
 
     @chip_key.setter
+    @_clears_cached_int
+    @_clears_cached_chip_key
     def chip_key(self, value):
-        # remove cached key
-        if hasattr(self, '_chip_key'):
-            del self._chip_key
         if value is None:
             self.io_channel = None
             self.io_group = None
@@ -256,10 +284,8 @@ class Packet_v2(object):
         return None
 
     @io_group.setter
+    @_clears_cached_chip_key
     def io_group(self, value):
-        if hasattr(self, '_chip_key'):
-            # remove cached key
-            del self._chip_key
         if value is None:
             if hasattr(self, '_io_group'):
                 del self._io_group
@@ -274,10 +300,8 @@ class Packet_v2(object):
         return None
 
     @io_channel.setter
+    @_clears_cached_chip_key
     def io_channel(self, value):
-        if hasattr(self, '_chip_key'):
-            # remove cached key
-            del self._chip_key
         if value is None:
             if hasattr(self, '_io_channel'):
                 del self._io_channel
@@ -292,6 +316,7 @@ class Packet_v2(object):
         return bah.touint(self.bits[self.timestamp_bits], endian=self.endian)
 
     @timestamp.setter
+    @_clears_cached_int
     def timestamp(self, value):
         if self.fifo_diagnostics_enabled:
             self.bits[self.fifo_diagnostics_timestamp_bits] = bah.fromuint(value, self.fifo_diagnostics_timestamp_bits, endian=self.endian)
@@ -303,6 +328,7 @@ class Packet_v2(object):
         return self.local_fifo%2
 
     @local_fifo_half.setter
+    @_clears_cached_int
     def local_fifo_half(self, value):
         self.local_fifo = self.local_fifo_full*2 + value
 
@@ -311,6 +337,7 @@ class Packet_v2(object):
         return self.local_fifo//2
 
     @local_fifo_full.setter
+    @_clears_cached_int
     def local_fifo_full(self, value):
         self.local_fifo = value*2 + self.local_fifo_half
 
@@ -319,6 +346,7 @@ class Packet_v2(object):
         return self.shared_fifo%2
 
     @shared_fifo_half.setter
+    @_clears_cached_int
     def shared_fifo_half(self, value):
         self.shared_fifo = self.shared_fifo_full*2 + value
 
@@ -327,12 +355,14 @@ class Packet_v2(object):
         return self.shared_fifo//2
 
     @shared_fifo_full.setter
+    @_clears_cached_int
     def shared_fifo_full(self, value):
         self.shared_fifo = value*2 + self.shared_fifo_half
 
     def compute_parity(self):
         return 1 - (self.bits[self.parity_calc_bits].count(True) % 2)
 
+    @_clears_cached_int
     def assign_parity(self):
         self.parity = self.compute_parity()
 
@@ -347,6 +377,7 @@ class Packet_v2(object):
         return None
 
     @local_fifo_events.setter
+    @_clears_cached_int
     def local_fifo_events(self, value):
         if self.fifo_diagnostics_enabled:
             bit_slice = self.local_fifo_events_bits
@@ -360,6 +391,7 @@ class Packet_v2(object):
         return None
 
     @shared_fifo_events.setter
+    @_clears_cached_int
     def shared_fifo_events(self, value):
         if self.fifo_diagnostics_enabled:
             bit_slice = self.shared_fifo_events_bits
@@ -371,32 +403,35 @@ class Packet_v2(object):
         return bah.touint(self.bits[bit_slice], endian=self.endian)
 
     @chip_id.setter
+    @_clears_cached_int
+    @_clears_cached_chip_key
     def chip_id(self, value):
-        if hasattr(self,'_chip_key'):
-            del self._chip_key
         bit_slice = self.chip_id_bits
         self.bits[bit_slice] = bah.fromuint(value, bit_slice, endian=self.endian)
 
-    def _basic_getter(name):
+    def _basic_getter(cls,name):
+        bit_slice = getattr(cls, name + '_bits')
+        mask = ~((2**cls.size)-1 << bit_slice.stop)
         def basic_getter_func(self):
-            bit_slice = getattr(self, name + '_bits')
-            return bah.touint(self.bits[bit_slice], endian=self.endian)
+            return (self.as_int() >> bit_slice.start) & mask
+            #return bah.touint(self.bits[bit_slice], endian=self.endian)
         return basic_getter_func
 
-    def _basic_setter(name):
+    def _basic_setter(cls,name):
+        bit_slice = getattr(cls, name + '_bits')
+        @_clears_cached_int
         def basic_setter_func(self, value):
-            bit_slice = getattr(self, name + '_bits')
             self.bits[bit_slice] = bah.fromuint(value, bit_slice, endian=self.endian)
         return basic_setter_func
 
-    packet_type = property(_basic_getter('packet_type'),_basic_setter('packet_type'))
-    downstream_marker = property(_basic_getter('downstream_marker'),_basic_setter('downstream_marker'))
-    parity = property(_basic_getter('parity'),_basic_setter('parity'))
-    channel_id = property(_basic_getter('channel_id'),_basic_setter('channel_id'))
-    dataword = property(_basic_getter('dataword'),_basic_setter('dataword'))
-    first_packet = property(_basic_getter('first_packet'),_basic_setter('first_packet'))
-    trigger_type = property(_basic_getter('trigger_type'),_basic_setter('trigger_type'))
-    register_address = property(_basic_getter('register_address'),_basic_setter('register_address'))
-    register_data = property(_basic_getter('register_data'),_basic_setter('register_data'))
-    local_fifo = property(_basic_getter('local_fifo'),_basic_setter('local_fifo'))
-    shared_fifo = property(_basic_getter('shared_fifo'),_basic_setter('shared_fifo'))
+Packet_v2.packet_type = property(Packet_v2._basic_getter(Packet_v2,'packet_type'),Packet_v2._basic_setter(Packet_v2,'packet_type'))
+Packet_v2.downstream_marker = property(Packet_v2._basic_getter(Packet_v2,'downstream_marker'),Packet_v2._basic_setter(Packet_v2,'downstream_marker'))
+Packet_v2.parity = property(Packet_v2._basic_getter(Packet_v2,'parity'),Packet_v2._basic_setter(Packet_v2,'parity'))
+Packet_v2.channel_id = property(Packet_v2._basic_getter(Packet_v2,'channel_id'),Packet_v2._basic_setter(Packet_v2,'channel_id'))
+Packet_v2.dataword = property(Packet_v2._basic_getter(Packet_v2,'dataword'),Packet_v2._basic_setter(Packet_v2,'dataword'))
+Packet_v2.first_packet = property(Packet_v2._basic_getter(Packet_v2,'first_packet'),Packet_v2._basic_setter(Packet_v2,'first_packet'))
+Packet_v2.trigger_type = property(Packet_v2._basic_getter(Packet_v2,'trigger_type'),Packet_v2._basic_setter(Packet_v2,'trigger_type'))
+Packet_v2.register_address = property(Packet_v2._basic_getter(Packet_v2,'register_address'),Packet_v2._basic_setter(Packet_v2,'register_address'))
+Packet_v2.register_data = property(Packet_v2._basic_getter(Packet_v2,'register_data'),Packet_v2._basic_setter(Packet_v2,'register_data'))
+Packet_v2.local_fifo = property(Packet_v2._basic_getter(Packet_v2,'local_fifo'),Packet_v2._basic_setter(Packet_v2,'local_fifo'))
+Packet_v2.shared_fifo = property(Packet_v2._basic_getter(Packet_v2,'shared_fifo'),Packet_v2._basic_setter(Packet_v2,'shared_fifo'))

--- a/larpix/packet/packet_v2.py
+++ b/larpix/packet/packet_v2.py
@@ -10,8 +10,7 @@ def _clears_cached_int(func):
 
     '''
     def new_func(self, *args, **kwargs):
-        if hasattr(self, '_int'):
-            del self._int
+        self._int = None
         return func(self, *args, **kwargs)
     return new_func
 
@@ -105,6 +104,8 @@ class Packet_v2(object):
         else:
             raise ValueError('Invalid number of bytes: %s' %
                     len(bytestream))
+        self._int = None
+        self.as_int()
 
     def __eq__(self, other):
         return self.bits == other.bits
@@ -246,7 +247,7 @@ class Packet_v2(object):
                 setattr(self, key, value)
 
     def as_int(self):
-        if not hasattr(self, '_int'):
+        if self._int is None:
             self._int = bah.touint(self.bits, endian=self.endian)
         return self._int
 

--- a/larpix/packet/packet_v2.py
+++ b/larpix/packet/packet_v2.py
@@ -94,6 +94,7 @@ class Packet_v2(object):
     endian = 'little'
 
     def __init__(self, bytestream=None):
+        self._int = None
         if bytestream is None:
             self.bits = bitarray(self.size,endian=self.endian)
             self.bits.setall(False)
@@ -104,7 +105,6 @@ class Packet_v2(object):
         else:
             raise ValueError('Invalid number of bytes: %s' %
                     len(bytestream))
-        self._int = None
 
     def __eq__(self, other):
         return self.bits == other.bits
@@ -409,6 +409,7 @@ class Packet_v2(object):
         bit_slice = self.chip_id_bits
         self.bits[bit_slice] = bah.fromuint(value, bit_slice, endian=self.endian)
 
+    @classmethod
     def _basic_getter(cls, name):
         bit_slice = getattr(cls, name + '_bits')
         mask = (~(((2**cls.size)-1 << (bit_slice.stop-bit_slice.start))) & (2**cls.size)-1)
@@ -416,6 +417,7 @@ class Packet_v2(object):
             return (self.as_int() >> bit_slice.start) & mask
         return basic_getter_func
 
+    @classmethod
     def _basic_setter(cls, name):
         bit_slice = getattr(cls, name + '_bits')
         @_clears_cached_int
@@ -423,14 +425,14 @@ class Packet_v2(object):
             self.bits[bit_slice] = bah.fromuint(value, bit_slice, endian=self.endian)
         return basic_setter_func
 
-Packet_v2.packet_type = property(Packet_v2._basic_getter(Packet_v2,'packet_type'),Packet_v2._basic_setter(Packet_v2,'packet_type'))
-Packet_v2.downstream_marker = property(Packet_v2._basic_getter(Packet_v2,'downstream_marker'),Packet_v2._basic_setter(Packet_v2,'downstream_marker'))
-Packet_v2.parity = property(Packet_v2._basic_getter(Packet_v2,'parity'),Packet_v2._basic_setter(Packet_v2,'parity'))
-Packet_v2.channel_id = property(Packet_v2._basic_getter(Packet_v2,'channel_id'),Packet_v2._basic_setter(Packet_v2,'channel_id'))
-Packet_v2.dataword = property(Packet_v2._basic_getter(Packet_v2,'dataword'),Packet_v2._basic_setter(Packet_v2,'dataword'))
-Packet_v2.first_packet = property(Packet_v2._basic_getter(Packet_v2,'first_packet'),Packet_v2._basic_setter(Packet_v2,'first_packet'))
-Packet_v2.trigger_type = property(Packet_v2._basic_getter(Packet_v2,'trigger_type'),Packet_v2._basic_setter(Packet_v2,'trigger_type'))
-Packet_v2.register_address = property(Packet_v2._basic_getter(Packet_v2,'register_address'),Packet_v2._basic_setter(Packet_v2,'register_address'))
-Packet_v2.register_data = property(Packet_v2._basic_getter(Packet_v2,'register_data'),Packet_v2._basic_setter(Packet_v2,'register_data'))
-Packet_v2.local_fifo = property(Packet_v2._basic_getter(Packet_v2,'local_fifo'),Packet_v2._basic_setter(Packet_v2,'local_fifo'))
-Packet_v2.shared_fifo = property(Packet_v2._basic_getter(Packet_v2,'shared_fifo'),Packet_v2._basic_setter(Packet_v2,'shared_fifo'))
+Packet_v2.packet_type = property(Packet_v2._basic_getter('packet_type'),Packet_v2._basic_setter('packet_type'))
+Packet_v2.downstream_marker = property(Packet_v2._basic_getter('downstream_marker'),Packet_v2._basic_setter('downstream_marker'))
+Packet_v2.parity = property(Packet_v2._basic_getter('parity'),Packet_v2._basic_setter('parity'))
+Packet_v2.channel_id = property(Packet_v2._basic_getter('channel_id'),Packet_v2._basic_setter('channel_id'))
+Packet_v2.dataword = property(Packet_v2._basic_getter('dataword'),Packet_v2._basic_setter('dataword'))
+Packet_v2.first_packet = property(Packet_v2._basic_getter('first_packet'),Packet_v2._basic_setter('first_packet'))
+Packet_v2.trigger_type = property(Packet_v2._basic_getter('trigger_type'),Packet_v2._basic_setter('trigger_type'))
+Packet_v2.register_address = property(Packet_v2._basic_getter('register_address'),Packet_v2._basic_setter('register_address'))
+Packet_v2.register_data = property(Packet_v2._basic_getter('register_data'),Packet_v2._basic_setter('register_data'))
+Packet_v2.local_fifo = property(Packet_v2._basic_getter('local_fifo'),Packet_v2._basic_setter('local_fifo'))
+Packet_v2.shared_fifo = property(Packet_v2._basic_getter('shared_fifo'),Packet_v2._basic_setter('shared_fifo'))

--- a/larpix/packet/packet_v2.py
+++ b/larpix/packet/packet_v2.py
@@ -105,7 +105,6 @@ class Packet_v2(object):
             raise ValueError('Invalid number of bytes: %s' %
                     len(bytestream))
         self._int = None
-        self.as_int()
 
     def __eq__(self, other):
         return self.bits == other.bits

--- a/scripts/convert_rawhdf5_to_hdf5.py
+++ b/scripts/convert_rawhdf5_to_hdf5.py
@@ -15,19 +15,16 @@ def main(input_filename, output_filename, block_size):
     last = time.time()
     for i_block in range(total_blocks):
         start = i_block * block_size
-        end = start + block_size
+        end = min(start + block_size, total_messages)
         if start == end: return
 
         if time.time() > last + 1:
-            print('reading block {} of {}...\r'.format(i_block,total_blocks),end='')
+            print('reading block {} of {}...\r'.format(i_block+1,total_blocks),end='')
             last = time.time()
         rd = from_rawfile(input_filename, start=start, end=end)
         pkts = list()
         for i_msg,data in enumerate(zip(rd['io_groups'], rd['msgs'])):
             io_group,msg = data
-            if time.time() > last + 1:
-                print('reading block {} of {}\tpacket {} of {}...\r'.format(i_block,total_blocks,i_msg,len(rd['msgs'])),end='')
-                last = time.time()
             pkts.extend(parse(msg, io_group=io_group))
         to_file(output_filename, packet_list=pkts)
     print()

--- a/scripts/convert_rawhdf5_to_hdf5.py
+++ b/scripts/convert_rawhdf5_to_hdf5.py
@@ -1,0 +1,42 @@
+import argparse
+import time
+
+import larpix
+import larpix.format.rawhdf5format
+import larpix.format.pacman_msg_format
+import larpix.format.hdf5format
+from larpix.format.rawhdf5format import from_rawfile, len_rawfile
+from larpix.format.pacman_msg_format import parse
+from larpix.format.hdf5format import to_file
+
+def main(input_filename, output_filename, block_size):
+    total_messages = len_rawfile(input_filename)
+    total_blocks = total_messages // block_size + 1
+    last = time.time()
+    for i_block in range(total_blocks):
+        start = i_block * block_size
+        end = start + block_size
+        if start == end: return
+
+        if time.time() > last + 1:
+            print('reading block {} of {}...\r'.format(i_block,total_blocks),end='')
+            last = time.time()
+        rd = from_rawfile(input_filename, start=start, end=end)
+        pkts = list()
+        for i_msg,data in enumerate(zip(rd['io_groups'], rd['msgs'])):
+            io_group,msg = data
+            if time.time() > last + 1:
+                print('reading block {} of {}\tpacket {} of {}...\r'.format(i_block,total_blocks,i_msg,len(rd['msgs'])),end='')
+                last = time.time()
+            pkts.extend(parse(msg, io_group=io_group))
+        to_file(output_filename, packet_list=pkts)
+    print()
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--input_filename', '-i', type=str, help='''Input hdf5 file, formatted with larpix.format.rawhdf5format using the larpix.io.PACMAN_IO class''')
+    parser.add_argument('--output_filename', '-o', type=str, help='''Output hdf5 file,
+        to be formatted with larpix.format.hdf5format''')
+    parser.add_argument('--block_size', default=10240, type=int, help='''Max number of messages to store in working memory (default=%(default)s)''')
+    args = parser.parse_args()
+    c = main(**vars(args))

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,7 @@ setup(
         classifiers=[
             'Development Status :: 4 - Beta',
             'Intended Audience :: Science/Research',
-            'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 2'
+            'Programming Language :: Python :: 3'
         ],
         keywords='dune physics',
         packages=find_packages(),
@@ -49,7 +48,8 @@ setup(
             ],
         scripts=[
             'scripts/gen_controller_config.py',
-            'scripts/gen_hydra_simple.py'
+            'scripts/gen_hydra_simple.py',
+            'scripts/convert_rawhdf5_to_hdf5.py'
             ],
         package_data={
             'larpix.configs': ['*/*.json'],

--- a/test/test_rawhdf5format.py
+++ b/test/test_rawhdf5format.py
@@ -1,0 +1,88 @@
+from __future__ import print_function
+
+import pytest
+import h5py
+
+from larpix.format.rawhdf5format import (to_rawfile, from_rawfile, len_rawfile)
+
+@pytest.fixture
+def tmpfile(tmpdir):
+    return str(tmpdir.join('test_raw.h5'))
+
+@pytest.fixture
+def testdata():
+    test_msgs = [
+        b'\x00'*8+b'\x01'*16,
+        b'\x01'*8+b'\x02'*16,
+        b'\x02'*8+b'\x03'*16
+        ]
+    test_io_groups = [
+        0,
+        1,
+        2
+    ]
+    return test_io_groups, test_msgs
+
+def test_incompatible_version(tmpfile):
+    to_rawfile(tmpfile, version='0.0')
+    with pytest.raises(AssertionError):
+        from_rawfile(tmpfile, version='1.0')
+        pytest.fail('Should identify incompatible version')
+    with pytest.raises(AssertionError):
+        from_rawfile(tmpfile, version='0.1')
+        pytest.fail('Should identify incompatible version')
+
+def test_file_empty_v0_0(tmpfile):
+    to_rawfile(tmpfile, version='0.0')
+    assert len_rawfile(tmpfile) == 0
+
+def test_file_full_v0_0(tmpfile, testdata):
+    io_groups, msgs = testdata
+    to_rawfile(tmpfile, msgs=msgs, io_groups=io_groups, version='0.0')
+    assert len_rawfile(tmpfile) == len(msgs)
+
+    rd = from_rawfile(tmpfile)
+    assert len(rd['msgs']) == len(msgs)
+    assert rd['msgs'][0] == msgs[0]
+    assert rd['msgs'][-1] == msgs[-1]
+    assert set(rd['msgs']) == set(msgs)
+    assert len(rd['io_groups']) == len(io_groups)
+    assert rd['io_groups'][0] == io_groups[0]
+    assert rd['io_groups'][-1] == io_groups[-1]
+    assert set(rd['io_groups']) == set(io_groups)
+
+def test_file_partial_read_v0_0(tmpfile, testdata):
+    io_groups, msgs = testdata
+    to_rawfile(tmpfile, msgs=msgs, io_groups=io_groups, version='0.0')
+
+    # read from end
+    rd = from_rawfile(tmpfile, start=-1)
+    assert len(rd['msgs']) == 1
+    assert rd['msgs'][0] == msgs[-1]
+    assert len(rd['io_groups']) == 1
+    assert rd['io_groups'][0] == io_groups[-1]
+
+    # read from middle
+    rd = from_rawfile(tmpfile, start=1, end=3)
+    assert len(rd['msgs']) == 2
+    assert rd['msgs'][0] == msgs[1]
+    assert len(rd['io_groups']) == 2
+    assert rd['io_groups'][0] == io_groups[1]
+
+def test_file_append_v0_0(tmpfile, testdata):
+    io_groups, msgs = testdata
+    to_rawfile(tmpfile, msgs=msgs, io_groups=io_groups, version='0.0')
+    to_rawfile(tmpfile, msgs=msgs[0:1], io_groups=io_groups[0:1], version='0.0')
+    assert len_rawfile(tmpfile) == len(msgs)+1
+
+    rd = from_rawfile(tmpfile)
+    assert len(rd['msgs']) == len(msgs)+1
+    assert rd['msgs'][0] == msgs[0]
+    assert rd['msgs'][-1] == msgs[0]
+    assert set(rd['msgs']) == set(msgs)
+    assert len(rd['io_groups']) == len(io_groups)+1
+    assert rd['io_groups'][0] == io_groups[0]
+    assert rd['io_groups'][-1] == io_groups[0]
+    assert set(rd['io_groups']) == set(io_groups)
+
+


### PR DESCRIPTION
Ok so this is a big PR, but here's the summary:

 - Drops python2 support to use a more recent h5py version

 - Extends `hdf5format` to use `multiprocessing` for the slow conversion of `Packet` objects to numpy arrays

 - Adds a cached `int` representation for `Packet_v2` objects to speed up attribute access

 - Introduces a new `rawhdf5format` for writing raw bytes to disk

 - Implements a means of bypassing the packet interpretation and write directly to the `rawhdf5format` from the `PACMAN_IO` class