### PR TITLE
Bumped up pytest and sphinx_rtd_theme versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,10 +34,10 @@ setup(
         packages=find_packages(),
         install_requires=[
             'pyserial ~=3.4',
-            'pytest ~=4.2',
+            'pytest ~=5.4',
             'bitarray ~=0.8',
             'pyzmq ~= 18.0',
-            'sphinx_rtd_theme ~= 0.4.2',
+            'sphinx_rtd_theme ~= 0.5',
             'numpy ~= 1.16',
             'h5py ~= 2.9',
             'bidict ~= 0.18.0',

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -1534,17 +1534,17 @@ def test_controller_get_chip_error(chip):
     test_key_dict = chip.chip_key.to_dict()
     test_key_dict['chip_id'] += 1
     test_key = Key.from_dict(test_key_dict)
-    with pytest.raises(ValueError, message='Should fail: bad chip id'):
+    with pytest.raises(ValueError):
         controller[test_key]
     test_key_dict = chip.chip_key.to_dict()
     test_key_dict['io_channel'] += 1
     test_key = Key.from_dict(test_key_dict)
-    with pytest.raises(ValueError, message='Should fail: bad channel id'):
+    with pytest.raises(ValueError):
         controller[test_key]
     test_key_dict = chip.chip_key.to_dict()
     test_key_dict['io_group'] += 1
     test_key = Key.from_dict(test_key_dict)
-    with pytest.raises(ValueError, message='Should fail: bad group id'):
+    with pytest.raises(ValueError):
         controller[test_key]
 
 def test_controller_read():


### PR DESCRIPTION
Bumped up pytest and sphinx_rtd_theme versions and removed `message` kwarg from `pytest.raises` (not allowed anymore)