### PR TITLE
Updating h5py and pytest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,12 +37,12 @@ setup(
         packages=find_packages(),
         install_requires=[
             'pyserial ~=3.4',
-            'pytest ~=5.4',
+            'pytest ~=6.2',
             'bitarray ~=0.8',
             'pyzmq ~= 18.0',
             'sphinx_rtd_theme ~= 0.5',
             'numpy ~= 1.16',
-            'h5py ~= 2.9',
+            'h5py ~= 3.1',
             'bidict ~= 0.18.0',
             'networkx ~= 2.2'
             ],


### PR DESCRIPTION
I am updating the versions of `h5py` and `pytest` so it works with the Cedar supercomputer Python environment. 