### PR TITLE
Improve config register fetch

### DIFF
--- a/larpix/chip.py
+++ b/larpix/chip.py
@@ -76,7 +76,7 @@ class Chip(object):
         if self.asic_version == 1:
             packet_register_data = enumerate(conf.all_data())
         elif self.asic_version in (2, 'lightpix-v1.0'):
-            packet_register_data = conf.some_data(registers)
+            packet_register_data = zip(*conf.some_data(registers))
         for i, data in packet_register_data:
             if i not in registers:
                 continue

--- a/larpix/chip.py
+++ b/larpix/chip.py
@@ -73,8 +73,11 @@ class Chip(object):
         if registers is None:
             registers = range(conf.num_registers)
         packets = []
-        packet_register_data = conf.all_data()
-        for i, data in enumerate(packet_register_data):
+        if self.asic_version == 1:
+            packet_register_data = enumerate(conf.all_data())
+        elif self.asic_version in (2, 'lightpix-v1.0'):
+            packet_register_data = conf.some_data(registers)
+        for i, data in packet_register_data:
             if i not in registers:
                 continue
             if self.asic_version == 1:

--- a/larpix/configuration/configuration_v2.py
+++ b/larpix/configuration/configuration_v2.py
@@ -69,6 +69,34 @@ class Configuration_v2(BaseConfiguration):
                         bits += [register_bits[::-1]]
         return bits
 
+    def some_data(self, registers, endian='little'):
+        '''
+        Fetch register addresses and data from a selected set of registers
+
+        :param registers: list of registers to fetch data for, specified either by register name (str) or register addresses (int)
+
+        :returns: tuple of list of register addresses and list of register data
+
+        '''
+        bits = []
+        addrs = []
+        for register in registers:
+            if isinstance(register, int):
+                register_name = self.register_map_inv[register][0]
+                register_data = getattr(self, register_name+'_data')
+            elif isinstance(register, str):
+                register_data = getattr(self, register+'_data')
+            for register_addr, register_bits in register_data:
+                if isinstance(register, int) and register_addr != register:
+                    continue
+                if endian[0] == 'l':
+                    bits += [register_bits]
+                    addrs += [register_addr]
+                else:
+                    bits += [register_bits[::-1]]
+                    addrs += [register_addr]
+        return addrs, bits
+
     def from_dict_registers(self, d, endian='little'):
         '''
         Load in the configuration specified by a dict of (register,

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -2,7 +2,9 @@ from larpix import Configuration_v2
 from bitarray import bitarray
 import larpix.bitarrayhelper as bah
 from larpix import configs
+
 import json
+import random
 
 def test_v2_conf_all_registers():
     default_filename = 'chip/default_v2.json'
@@ -229,3 +231,47 @@ def test_get_nondefault_registers():
             'csa_enable': [({'index': 35, 'value': 0}, {'index': 35,
                 'value': 1})],
             }
+
+def test_v2_conf_all_data():
+    c = Configuration_v2()
+    config_data = c.all_data()
+
+    assert len(config_data) == c.num_registers, \
+        f'config data length incorrect (should be {c.num_registers}, is {len(config_data)})'
+
+    for reg_name in c.register_map.keys():
+        reg_data = getattr(c, f'{reg_name}_data')
+        for reg_addr, bits in reg_data:
+            assert bits == config_data[reg_addr], \
+                f'register {reg_addr} mismatch (should be {bits}, is {config_data[reg_addr]})'
+
+def test_v2_conf_some_data():
+    c = Configuration_v2()
+
+    req_addrs = range(c.num_registers)
+    addrs, bits = c.some_data(req_addrs)
+    config_data = c.all_data()
+
+    # check all addresses
+    assert len(addrs) == len(req_addrs), \
+        f'config data length incorrect (should be {len(req_addrs)}, is {len(addrs)})'
+    assert set(addrs) == set(req_addrs), \
+        f'config data values incorrect (should be {set(req_addrs)}, is {set(addrs)})'
+
+    for addr, addr_bits in zip(addrs, bits):
+        assert addr_bits == config_data[addr], \
+            f'register {addr} mismatch (should be {config_data[addr]}, is {addr_bits})'
+
+    # check partial addresses
+    req_addrs = random.sample(range(c.num_registers), c.num_registers//2)
+    addrs, bits = c.some_data(req_addrs)
+
+    # check all addresses
+    assert len(addrs) == len(req_addrs), \
+        f'config data length incorrect (should be {len(req_addrs)}, is {len(addrs)})'
+    assert set(addrs) == set(req_addrs), \
+        f'config data values incorrect (should be {set(req_addrs)}, is {set(addrs)})'
+
+    for addr, addr_bits in zip(addrs, bits):
+        assert addr_bits == config_data[addr], \
+            f'register {addr} mismatch (should be {config_data[addr]}, is {addr_bits})'


### PR DESCRIPTION
Configuration register data within the Chip object was generated in a very inefficient manner (all registers for any config write/read). This PR adds a `some_data` method to the configuration_v2 class that can be used to generate only the register data that is needed for the read/write.