### PR TITLE
Add hdf5 utility scripts

### DIFF
--- a/scripts/packet_hdf5_tool.py
+++ b/scripts/packet_hdf5_tool.py
@@ -1,0 +1,87 @@
+#!/usr/env/bin python3
+'''
+Usage
+=====
+To merge larpix packet-formatted hdf5 files together::
+
+    packethdf5_tool.py --merge -i <files to merge, in order> -o <destination filename>
+
+> Note:
+>
+> When merging files, there is the possibility of losing some file meta data. The
+> merge behavior will only keep the metadata of each dataset coming from the first
+> file. It is highly recommended that you only `merge` files where the metadata
+> guaranteed to be the same (i.e. many files of the same simulation run).
+
+'''
+import h5py
+import warnings
+import os
+try:
+    from tqdm import tqdm
+    _has_tqdm = True
+except Exception as e:
+    warnings.warn(e)
+    _has_tqdm = False
+
+_default_max_length = -1
+_default_block_size = 102400
+
+def move_dataset(input_file, output_file, dset_name, curr_idx, block_size):
+    output_file[dset_name].resize((len(output_file[dset_name]) + len(input_file[dset_name]),))
+    # copy data in chunks
+    for start in tqdm(range(0, len(input_file[dset_name]), block_size)) if _has_tqdm else range(0, len(input_file[dset_name]), block_size):
+        end = min(start+block_size, len(input_file[dset_name]))
+        prev_idx = curr_idx
+        curr_idx += end - start
+        output_file[dset_name][prev_idx:curr_idx] = input_file[dset_name][start:end]
+
+def merge_files(input_filenames, output_filename, block_size):
+    with h5py.File(output_filename, 'w') as fo:
+        curr_idx = 0
+        for i,input_filename in enumerate(input_filenames):
+            print(input_filename, '{}/{}'.format(i+1, len(input_filenames)))
+            with h5py.File(input_filename, 'r') as fi:
+                if i == 0:
+                    # create datasets and groups
+                    fo.create_group('_header')
+
+                    # create datasets
+                    for dset_name in fi.keys():
+                        if isinstance(fi[dset_name], h5py.Dataset):
+                            fo.create_dataset(dset_name, shape=(0,), maxshape=(None,), compression='gzip', dtype=fi[dset_name].dtype)
+
+                        # copy meta data
+                        for attr,value in fi[dset_name].attrs.items():
+                            fo[dset_name].attrs[attr] = value
+
+                # copy data
+                for dset_name in fi.keys():
+                    if isinstance(fi[dset_name], h5py.Dataset):
+                        print('copying',dset_name,'...')
+                        move_dataset(fi, fo, dset_name, curr_idx, block_size)
+
+
+def main(input_filenames, output_filename, max_length=_default_max_length, block_size=_default_block_size, **kwargs):
+    if kwargs.get('merge', False):
+        merge_files(
+            input_filenames, output_filename,
+            block_size=block_size
+            )
+    else:
+        print('No action specified, exiting.')
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('-i', nargs='+', required=True, help='Input file(s)')
+    parser.add_argument('-o', required=True, type=str, help='Output file')
+    parser.add_argument('--block_size', type=int, default=_default_block_size, required=False, help='Block size used for reads (default=%(default)s)')
+    parser.add_argument('--merge', action='store_true', help='Flag to merge files')
+    args = parser.parse_args()
+    main(
+        input_filenames=args.i,
+        output_filename=args.o,
+        **vars(args)
+        )

--- a/scripts/packet_hdf5_tool.py
+++ b/scripts/packet_hdf5_tool.py
@@ -27,7 +27,8 @@ except Exception as e:
 _default_max_length = -1
 _default_block_size = 102400
 
-def move_dataset(input_file, output_file, dset_name, curr_idx, block_size):
+def move_dataset(input_file, output_file, dset_name, block_size):
+    curr_idx = len(output_file[dset_name])
     output_file[dset_name].resize((len(output_file[dset_name]) + len(input_file[dset_name]),))
     # copy data in chunks
     for start in tqdm(range(0, len(input_file[dset_name]), block_size)) if _has_tqdm else range(0, len(input_file[dset_name]), block_size):
@@ -38,7 +39,6 @@ def move_dataset(input_file, output_file, dset_name, curr_idx, block_size):
 
 def merge_files(input_filenames, output_filename, block_size):
     with h5py.File(output_filename, 'w') as fo:
-        curr_idx = 0
         for i,input_filename in enumerate(input_filenames):
             print(input_filename, '{}/{}'.format(i+1, len(input_filenames)))
             with h5py.File(input_filename, 'r') as fi:
@@ -56,10 +56,10 @@ def merge_files(input_filenames, output_filename, block_size):
                             fo[dset_name].attrs[attr] = value
 
                 # copy data
-                for dset_name in fi.keys():
-                    if isinstance(fi[dset_name], h5py.Dataset):
+                for dset_name in fo.keys():
+                    if isinstance(fo[dset_name], h5py.Dataset):
                         print('copying',dset_name,'...')
-                        move_dataset(fi, fo, dset_name, curr_idx, block_size)
+                        move_dataset(fi, fo, dset_name, block_size)
 
 
 def main(input_filenames, output_filename, max_length=_default_max_length, block_size=_default_block_size, **kwargs):

--- a/scripts/packet_hdf5_tool.py
+++ b/scripts/packet_hdf5_tool.py
@@ -21,7 +21,7 @@ try:
     from tqdm import tqdm
     _has_tqdm = True
 except Exception as e:
-    warnings.warn(e)
+    warnings.warn(str(e), RuntimeWarning)
     _has_tqdm = False
 
 _default_max_length = -1

--- a/scripts/raw_hdf5_tool.py
+++ b/scripts/raw_hdf5_tool.py
@@ -69,16 +69,17 @@ def split_file(input_filename, output_directory, max_length, block_size):
         i = 0
         curr_idx, prev_idx = 0, 0
         fo = None
+
         try:
             for start in tqdm(range(0, len(fi['msgs']), block_size)) if _has_tqdm else range(0, len(fi['msgs']), block_size):
                 end = min(start+block_size, len(fi['msgs']))
 
-                if fo is None or (curr_idx >= max_length and max_length > 0):
+                if fo is None or (os.stat(output_filename).st_size >= max_length and max_length > 0):
                     # open next file
                     if fo is not None:
                         fo.close()
-                    fo = h5py.File(output_filename_fmt.format(i), 'a', libver='latest')
-                    print(output_filename_fmt.format(i))
+                    output_filename = output_filename_fmt.format(i)
+                    fo = h5py.File(output_filename, 'a', libver='latest')
                     i += 1
                     curr_idx, prev_idx = 0, 0
 
@@ -88,7 +89,7 @@ def split_file(input_filename, output_directory, max_length, block_size):
                     fo.create_dataset('msg_headers', shape=(0,), maxshape=(None,), compression='gzip', dtype=fi['msg_headers'].dtype)
 
                     # copy meta data
-                    for attr,value in fi['meta'].items():
+                    for attr,value in fi['meta'].attrs.items():
                         fo['meta'].attrs[attr] = value
 
                     fo.swmr_mode = True

--- a/scripts/raw_hdf5_tool.py
+++ b/scripts/raw_hdf5_tool.py
@@ -69,7 +69,7 @@ def split_file(input_filename, output_directory, max_length, block_size):
         i = 0
         curr_idx, prev_idx = 0, 0
         fo = None
-
+        output_filename = output_filename_fmt.format(i)
         try:
             for start in tqdm(range(0, len(fi['msgs']), block_size)) if _has_tqdm else range(0, len(fi['msgs']), block_size):
                 end = min(start+block_size, len(fi['msgs']))

--- a/scripts/raw_hdf5_tool.py
+++ b/scripts/raw_hdf5_tool.py
@@ -104,8 +104,8 @@ def split_file(input_filename, output_directory, max_length, block_size):
                 fo['msgs'][prev_idx:curr_idx] = fi['msgs'][start:end]
                 fo['msg_headers'][prev_idx:curr_idx] = fi['msg_headers'][start:end]
 
-                f['msgs'].flush()
-                f['msg_headers'].flush()
+                fo['msgs'].flush()
+                fo['msg_headers'].flush()
         except:
             raise
         finally:

--- a/scripts/raw_hdf5_tool.py
+++ b/scripts/raw_hdf5_tool.py
@@ -1,0 +1,139 @@
+#!/usr/env/bin python3
+'''
+Usage
+=====
+To merge larpix raw-formatted hdf5 files together::
+
+    rawhdf5_tool.py --merge -i <files to merge, in order> -o <destination filename>
+
+To split a single larpix raw-formatted hdf5 file into many::
+
+    rawhdf5_tool.py --split -i <file to split> -o <destination directory> --max_length=<dataset length to split>
+
+> Note:
+>
+> When merging files, there is the possibility of losing file metadata that is
+> necessary to parse the file. The merge behavior will only keep the metadata of each
+> dataset coming from the first file. It is highly recommended that you only
+> `merge` files that were `split` using this utility, or files where the metadata
+> guaranteed to be the same (i.e. many files of the same simulation run).
+
+'''
+import h5py
+import warnings
+import os
+try:
+    from tqdm import tqdm
+    _has_tqdm = True
+except Exception as e:
+    warnings.warn(e)
+    _has_tqdm = False
+
+_default_max_length = -1
+_default_block_size = 102400
+
+def merge_files(input_filenames, output_filename, block_size):
+    with h5py.File(output_filename, 'w', libver='latest') as fo:
+        curr_idx = 0
+        prev_idx = 0
+        for i,input_filename in enumerate(input_filenames):
+            print(input_filename, '{}/{}'.format(i+1, len(input_filenames)))
+            with h5py.File(input_filename, 'r', libver='latest', swmr=True) as fi:
+                if i == 0:
+                    # create datasets and groups
+                    fo.create_group('meta')
+                    fo.create_dataset('msgs', shape=fi['msgs'].shape, maxshape=(None,), compression='gzip', dtype=fi['msgs'].dtype)
+                    fo.create_dataset('msg_headers', shape=fi['msg_headers'].shape, maxshape=(None,), compression='gzip', dtype=fi['msg_headers'].dtype)
+
+                    # copy meta data
+                    for attr,value in fi['meta'].attrs.items():
+                        fo['meta'].attrs[attr] = value
+                else:
+                    # resize datasets
+                    fo['msgs'].resize((len(fo['msgs']) + len(fi['msgs']),))
+                    fo['msg_headers'].resize((len(fo['msg_headers']) + len(fi['msg_headers']),))
+
+                # copy data in chunks
+                for start in tqdm(range(0, len(fi['msgs']), block_size)) if _has_tqdm else range(0, len(fi['msgs']), block_size):
+                    end = min(start+block_size, len(fi['msgs']))
+                    prev_idx = curr_idx
+                    curr_idx += end - start
+                    fo['msgs'][prev_idx:curr_idx] = fi['msgs'][start:end]
+                    fo['msg_headers'][prev_idx:curr_idx] = fi['msg_headers'][start:end]
+    return
+
+def split_file(input_filename, output_directory, max_length, block_size):
+    with h5py.File(input_filename, 'r') as fi:
+        output_filename_fmt = os.path.join(output_directory, os.path.basename(input_filename)[:-2]) + '{}.h5'
+
+        i = 0
+        curr_idx, prev_idx = 0, 0
+        fo = None
+        try:
+            for start in tqdm(range(0, len(fi['msgs']), block_size)) if _has_tqdm else range(0, len(fi['msgs']), block_size):
+                end = min(start+block_size, len(fi['msgs']))
+
+                if fo is None or (curr_idx >= max_length and max_length > 0):
+                    # open next file
+                    if fo is not None:
+                        fo.close()
+                    fo = h5py.File(output_filename_fmt.format(i), 'a', libver='latest')
+                    print(output_filename_fmt.format(i))
+                    i += 1
+                    curr_idx, prev_idx = 0, 0
+
+                    # create datasets and groups
+                    fo.create_group('meta')
+                    fo.create_dataset('msgs', shape=(0,), maxshape=(None,), compression='gzip', dtype=fi['msgs'].dtype)
+                    fo.create_dataset('msg_headers', shape=(0,), maxshape=(None,), compression='gzip', dtype=fi['msg_headers'].dtype)
+
+                    # copy meta data
+                    for attr,value in fi['meta'].items():
+                        fo['meta'].attrs[attr] = value
+
+                # resize datasets
+                prev_idx = curr_idx
+                curr_idx += end - start
+                fo['msgs'].resize((curr_idx,))
+                fo['msg_headers'].resize((curr_idx,))
+
+                # copy data
+                fo['msgs'][prev_idx:curr_idx] = fi['msgs'][start:end]
+                fo['msg_headers'][prev_idx:curr_idx] = fi['msg_headers'][start:end]
+        except:
+            raise
+        finally:
+            if fo is not None:
+                fo.close()
+    return
+
+def main(input_filenames, output_filename, max_length=_default_max_length, block_size=_default_block_size, **kwargs):
+    if kwargs.get('merge', False):
+        merge_files(
+            input_filenames, output_filename,
+            block_size=block_size
+            )
+    elif kwargs.get('split', False):
+        split_file(
+            input_filenames[0], output_filename,
+            max_length=max_length, block_size=block_size
+            )
+    else:
+        print('No action specified, exiting.')
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('-i', nargs='+', required=True, help='Input file(s)')
+    parser.add_argument('-o', required=True, type=str, help='Output file or directory')
+    parser.add_argument('--max_length', type=int, default=_default_max_length, required=False, help='Max dataset length (split only, default=%(default)s)')
+    parser.add_argument('--block_size', type=int, default=_default_block_size, required=False, help='Block size used for reads (default=%(default)s)')
+    parser.add_argument('--merge', action='store_true', help='Flag to merge files')
+    parser.add_argument('--split', action='store_true', help='Flag to split files')
+    args = parser.parse_args()
+    main(
+        input_filenames=args.i,
+        output_filename=args.o,
+        **vars(args)
+        )

--- a/scripts/raw_hdf5_tool.py
+++ b/scripts/raw_hdf5_tool.py
@@ -26,7 +26,7 @@ try:
     from tqdm import tqdm
     _has_tqdm = True
 except Exception as e:
-    warnings.warn(e)
+    warnings.warn(str(e), RuntimeWarning)
     _has_tqdm = False
 
 _default_max_length = -1

--- a/scripts/raw_hdf5_tool.py
+++ b/scripts/raw_hdf5_tool.py
@@ -133,7 +133,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('-i', nargs='+', required=True, help='Input file(s)')
     parser.add_argument('-o', required=True, type=str, help='Output file or directory')
-    parser.add_argument('--max_length', type=int, default=_default_max_length, required=False, help='Max dataset length (split only, default=%(default)s)')
+    parser.add_argument('--max_length', type=int, default=_default_max_length, required=False, help='Max dataset length (split only, default=%(default)s bytes)')
     parser.add_argument('--block_size', type=int, default=_default_block_size, required=False, help='Block size used for reads (default=%(default)s)')
     parser.add_argument('--merge', action='store_true', help='Flag to merge files')
     parser.add_argument('--split', action='store_true', help='Flag to split files')

--- a/scripts/raw_hdf5_tool.py
+++ b/scripts/raw_hdf5_tool.py
@@ -63,7 +63,7 @@ def merge_files(input_filenames, output_filename, block_size):
     return
 
 def split_file(input_filename, output_directory, max_length, block_size):
-    with h5py.File(input_filename, 'r') as fi:
+    with h5py.File(input_filename, 'r', libver='latest', swmr=True) as fi:
         output_filename_fmt = os.path.join(output_directory, os.path.basename(input_filename)[:-2]) + '{}.h5'
 
         i = 0
@@ -91,6 +91,8 @@ def split_file(input_filename, output_directory, max_length, block_size):
                     for attr,value in fi['meta'].items():
                         fo['meta'].attrs[attr] = value
 
+                    fo.swmr_mode = True
+
                 # resize datasets
                 prev_idx = curr_idx
                 curr_idx += end - start
@@ -100,6 +102,9 @@ def split_file(input_filename, output_directory, max_length, block_size):
                 # copy data
                 fo['msgs'][prev_idx:curr_idx] = fi['msgs'][start:end]
                 fo['msg_headers'][prev_idx:curr_idx] = fi['msg_headers'][start:end]
+
+                f['msgs'].flush()
+                f['msg_headers'].flush()
         except:
             raise
         finally:

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,9 @@ setup(
         scripts=[
             'scripts/gen_controller_config.py',
             'scripts/gen_hydra_simple.py',
-            'scripts/convert_rawhdf5_to_hdf5.py'
+            'scripts/convert_rawhdf5_to_hdf5.py',
+            'scripts/packet_hdf5_tool.py',
+            'scripts/raw_hdf5_tool.py'
             ],
         package_data={
             'larpix.configs': ['*/*.json'],

--- a/test/test_scripts.py
+++ b/test/test_scripts.py
@@ -49,8 +49,7 @@ def test_convert_rawhdf5_to_hdf5(tmpdir, raw_hdf5_tmpfile):
     # test read from file
     new_packets = p_h5_fmt.from_file(out_filename)['packets']
     orig_packets = [p_msg_fmt.parse(msg) for msg in r_h5_fmt.from_rawfile(raw_hdf5_tmpfile)['msgs']]
-    assert new_packets == [p for pkts in orig_packets for p in pkts], \
-        f'Return code: {proc.returncode}\nout: {out}'
+    assert new_packets == [p for pkts in orig_packets for p in pkts]
 
 def test_packet_hdf5_tool(tmpdir, packet_hdf5_tmpfile, test_packets):
     out_filename = os.path.join(tmpdir, 'datalog_tool_test.h5')

--- a/test/test_scripts.py
+++ b/test/test_scripts.py
@@ -1,0 +1,105 @@
+import pytest
+import os
+import subprocess
+
+from larpix import TimestampPacket, Packet_v2, SyncPacket, TriggerPacket
+import larpix.format.rawhdf5format as r_h5_fmt
+import larpix.format.hdf5format as p_h5_fmt
+import larpix.format.pacman_msg_format as p_msg_fmt
+
+@pytest.fixture
+def test_packets():
+    pkts = []
+    for _ in range(10):
+        pkts += [[]]
+        pkts[-1] += [TimestampPacket(0)]
+        pkts[-1] += [Packet_v2(b'\x00\x00\x00\x00\x00\x00\x00\x01')] * 10
+        pkts[-1] += [TriggerPacket(b'\x00', 0, 0)]
+        pkts[-1] += [SyncPacket(b'\x00', 0, 0, 0)]
+    return pkts
+
+@pytest.fixture
+def raw_hdf5_tmpfile(tmpdir, test_packets):
+    msgs = [p_msg_fmt.format([pkts]) for pkts in test_packets]
+    io_groups = [0 for _ in test_packets]
+
+    test_filename = os.path.join(tmpdir,'raw_test.h5')
+    r_h5_fmt.to_rawfile(
+        test_filename, msgs=msgs, msg_headers={'io_groups': io_groups}
+        )
+    return test_filename
+
+@pytest.fixture
+def packet_hdf5_tmpfile(tmpdir, test_packets):
+    test_filename = os.path.join(tmpdir,'datalog_test.h5')
+    p_h5_fmt.to_file(
+        test_filename,
+        packet_list=[p for pkts in test_packets for p in pkts]
+        )
+    return test_filename
+
+def test_convert_rawhdf5_to_hdf5(tmpdir, raw_hdf5_tmpfile):
+    out_filename = os.path.join(tmpdir, 'datalog_convert_test.h5')
+    proc = subprocess.run(
+        ['convert_rawhdf5_to_hdf5.py', '-i', raw_hdf5_tmpfile, '-o', out_filename],
+        capture_output=True
+        )
+    out = proc.stdout.decode('utf-8') + '\n' + proc.stderr.decode('utf-8')
+    assert proc.returncode == 0, \
+        f'Return code: {proc.returncode}\nout: {out}'
+
+    # test read from file
+    new_packets = p_h5_fmt.from_file(out_filename)['packets']
+    orig_packets = [p_msg_fmt.parse(msg) for msg in r_h5_fmt.from_rawfile(raw_hdf5_tmpfile)['msgs']]
+    assert new_packets == [p for pkts in orig_packets for p in pkts], \
+        f'Return code: {proc.returncode}\nout: {out}'
+
+def test_packet_hdf5_tool(tmpdir, packet_hdf5_tmpfile, test_packets):
+    out_filename = os.path.join(tmpdir, 'datalog_tool_test.h5')
+
+    # test merge
+    proc = subprocess.run(
+        ['packet_hdf5_tool.py', '--merge', '-i', packet_hdf5_tmpfile, packet_hdf5_tmpfile, '-o', out_filename],
+        capture_output=True
+        )
+    out = proc.stdout.decode('utf-8') + '\n' + proc.stderr.decode('utf-8')
+    assert proc.returncode == 0, \
+        f'Return code: {proc.returncode}\nout: {out}'
+
+    # test read from file
+    orig_packets = p_h5_fmt.from_file(packet_hdf5_tmpfile)['packets']
+    orig_packets += p_h5_fmt.from_file(packet_hdf5_tmpfile)['packets']
+    new_packets = p_h5_fmt.from_file(out_filename)['packets']
+    assert len(orig_packets) == len(new_packets)
+    print(orig_packets[:10])
+    print(new_packets[:10])
+    assert orig_packets == new_packets, \
+        f'Return code: {proc.returncode}\nout: {out}'
+
+def test_raw_hdf5_tool(tmpdir, raw_hdf5_tmpfile, test_packets):
+    out_filename = os.path.join(tmpdir, 'raw_tool_test.h5')
+
+    # test merge
+    proc = subprocess.run(
+        ['raw_hdf5_tool.py', '--merge', '-i', raw_hdf5_tmpfile, raw_hdf5_tmpfile, '-o', out_filename],
+        capture_output=True
+        )
+    out = proc.stdout.decode('utf-8') + '\n' + proc.stderr.decode('utf-8')
+    assert proc.returncode == 0, \
+        f'Return code: {proc.returncode}\nout: {out}'
+
+    # test read data
+    assert r_h5_fmt.from_rawfile(raw_hdf5_tmpfile)['msgs'] + r_h5_fmt.from_rawfile(raw_hdf5_tmpfile)['msgs'] == r_h5_fmt.from_rawfile(out_filename)['msgs']
+
+    # test merge
+    proc = subprocess.run(
+        ['raw_hdf5_tool.py', '--split', '-i', out_filename, '-o', tmpdir, '--max_length', '0'],
+        capture_output=True
+        )
+    out = proc.stdout.decode('utf-8') + '\n' + proc.stderr.decode('utf-8')
+    assert proc.returncode == 0, \
+        f'Return code: {proc.returncode}\nout: {out}'
+
+    # test read data
+    assert r_h5_fmt.from_rawfile(raw_hdf5_tmpfile)['msgs'] + r_h5_fmt.from_rawfile(raw_hdf5_tmpfile)['msgs'] == r_h5_fmt.from_rawfile(out_filename)['msgs']
+

--- a/test/test_scripts.py
+++ b/test/test_scripts.py
@@ -42,11 +42,9 @@ def packet_hdf5_tmpfile(tmpdir, test_packets):
 def test_convert_rawhdf5_to_hdf5(tmpdir, raw_hdf5_tmpfile):
     out_filename = os.path.join(tmpdir, 'datalog_convert_test.h5')
     proc = subprocess.run(
-        ['convert_rawhdf5_to_hdf5.py', '-i', raw_hdf5_tmpfile, '-o', out_filename, '--block_size', '10']
+        ['convert_rawhdf5_to_hdf5.py', '-i', raw_hdf5_tmpfile, '-o', out_filename, '--block_size', '10'],
+        check=True
         )
-    out = proc.stdout.decode('utf-8') + '\n' + proc.stderr.decode('utf-8') if sys.version_info[1] == 6 else None
-    assert proc.returncode == 0, \
-        f'Return code: {proc.returncode}\nout: {out}'
 
     # test read from file
     new_packets = p_h5_fmt.from_file(out_filename)['packets']
@@ -59,41 +57,34 @@ def test_packet_hdf5_tool(tmpdir, packet_hdf5_tmpfile, test_packets):
 
     # test merge
     proc = subprocess.run(
-        ['packet_hdf5_tool.py', '--merge', '-i', packet_hdf5_tmpfile, packet_hdf5_tmpfile, '-o', out_filename, '--block_size', '10']
+        ['packet_hdf5_tool.py', '--merge', '-i', packet_hdf5_tmpfile, packet_hdf5_tmpfile, '-o', out_filename, '--block_size', '10'],
+        check=True
         )
-    out = proc.stdout.decode('utf-8') + '\n' + proc.stderr.decode('utf-8') if sys.version_info[1] == 6 else None
-    assert proc.returncode == 0, \
-        f'Return code: {proc.returncode}\nout: {out}'
 
     # test read from file
     orig_packets = p_h5_fmt.from_file(packet_hdf5_tmpfile)['packets']
     orig_packets += p_h5_fmt.from_file(packet_hdf5_tmpfile)['packets']
     new_packets = p_h5_fmt.from_file(out_filename)['packets']
     assert len(orig_packets) == len(new_packets)
-    assert orig_packets == new_packets, \
-        f'Return code: {proc.returncode}\nout: {out}'
+    assert orig_packets == new_packets
 
 def test_raw_hdf5_tool(tmpdir, raw_hdf5_tmpfile, test_packets):
     out_filename = os.path.join(tmpdir, 'raw_tool_test.h5')
 
     # test merge
     proc = subprocess.run(
-        ['raw_hdf5_tool.py', '--merge', '-i', raw_hdf5_tmpfile, raw_hdf5_tmpfile, '-o', out_filename, '--block_size', '10']
+        ['raw_hdf5_tool.py', '--merge', '-i', raw_hdf5_tmpfile, raw_hdf5_tmpfile, '-o', out_filename, '--block_size', '10'],
+        check=True
         )
-    out = proc.stdout.decode('utf-8') + '\n' + proc.stderr.decode('utf-8') if sys.version_info[1] == 6 else None
-    assert proc.returncode == 0, \
-        f'Return code: {proc.returncode}\nout: {out}'
 
     # test read data
     assert r_h5_fmt.from_rawfile(raw_hdf5_tmpfile)['msgs'] + r_h5_fmt.from_rawfile(raw_hdf5_tmpfile)['msgs'] == r_h5_fmt.from_rawfile(out_filename)['msgs']
 
     # test merge
     proc = subprocess.run(
-        ['raw_hdf5_tool.py', '--split', '-i', out_filename, '-o', tmpdir, '--max_length', '0', '--block_size', '10']
+        ['raw_hdf5_tool.py', '--split', '-i', out_filename, '-o', tmpdir, '--max_length', '0', '--block_size', '10'],
+        check=True
         )
-    out = proc.stdout.decode('utf-8') + '\n' + proc.stderr.decode('utf-8') if sys.version_info[1] == 6 else None
-    assert proc.returncode == 0, \
-        f'Return code: {proc.returncode}\nout: {out}'
 
     # test read data
     assert r_h5_fmt.from_rawfile(raw_hdf5_tmpfile)['msgs'] + r_h5_fmt.from_rawfile(raw_hdf5_tmpfile)['msgs'] == r_h5_fmt.from_rawfile(out_filename)['msgs']

--- a/test/test_scripts.py
+++ b/test/test_scripts.py
@@ -42,8 +42,8 @@ def packet_hdf5_tmpfile(tmpdir, test_packets):
 def test_convert_rawhdf5_to_hdf5(tmpdir, raw_hdf5_tmpfile):
     out_filename = os.path.join(tmpdir, 'datalog_convert_test.h5')
     proc = subprocess.run(
-        ['convert_rawhdf5_to_hdf5.py', '-i', raw_hdf5_tmpfile, '-o', out_filename, '--block_size', '10'],
-        check=True
+        ['python', 'convert_rawhdf5_to_hdf5.py', '-i', raw_hdf5_tmpfile, '-o', out_filename, '--block_size', '10'],
+        check=True, shell=True
         )
 
     # test read from file
@@ -56,8 +56,8 @@ def test_packet_hdf5_tool(tmpdir, packet_hdf5_tmpfile, test_packets):
 
     # test merge
     proc = subprocess.run(
-        ['packet_hdf5_tool.py', '--merge', '-i', packet_hdf5_tmpfile, packet_hdf5_tmpfile, '-o', out_filename, '--block_size', '10'],
-        check=True
+        ['python', 'packet_hdf5_tool.py', '--merge', '-i', packet_hdf5_tmpfile, packet_hdf5_tmpfile, '-o', out_filename, '--block_size', '10'],
+        check=True, shell=True
         )
 
     # test read from file
@@ -72,8 +72,8 @@ def test_raw_hdf5_tool(tmpdir, raw_hdf5_tmpfile, test_packets):
 
     # test merge
     proc = subprocess.run(
-        ['raw_hdf5_tool.py', '--merge', '-i', raw_hdf5_tmpfile, raw_hdf5_tmpfile, '-o', out_filename, '--block_size', '10'],
-        check=True
+        ['python', 'raw_hdf5_tool.py', '--merge', '-i', raw_hdf5_tmpfile, raw_hdf5_tmpfile, '-o', out_filename, '--block_size', '10'],
+        check=True, shell=True
         )
 
     # test read data
@@ -81,8 +81,8 @@ def test_raw_hdf5_tool(tmpdir, raw_hdf5_tmpfile, test_packets):
 
     # test merge
     proc = subprocess.run(
-        ['raw_hdf5_tool.py', '--split', '-i', out_filename, '-o', tmpdir, '--max_length', '0', '--block_size', '10'],
-        check=True
+        ['python', 'raw_hdf5_tool.py', '--split', '-i', out_filename, '-o', tmpdir, '--max_length', '0', '--block_size', '10'],
+        check=True, shell=True
         )
 
     # test read data

--- a/test/test_scripts.py
+++ b/test/test_scripts.py
@@ -10,7 +10,7 @@ import larpix.format.pacman_msg_format as p_msg_fmt
 @pytest.fixture
 def test_packets():
     pkts = []
-    for _ in range(10):
+    for _ in range(100):
         pkts += [[]]
         pkts[-1] += [TimestampPacket(0)]
         pkts[-1] += [Packet_v2(b'\x00\x00\x00\x00\x00\x00\x00\x01')] * 10
@@ -41,7 +41,7 @@ def packet_hdf5_tmpfile(tmpdir, test_packets):
 def test_convert_rawhdf5_to_hdf5(tmpdir, raw_hdf5_tmpfile):
     out_filename = os.path.join(tmpdir, 'datalog_convert_test.h5')
     proc = subprocess.run(
-        ['convert_rawhdf5_to_hdf5.py', '-i', raw_hdf5_tmpfile, '-o', out_filename],
+        ['convert_rawhdf5_to_hdf5.py', '-i', raw_hdf5_tmpfile, '-o', out_filename, '--block_size', '10'],
         capture_output=True
         )
     out = proc.stdout.decode('utf-8') + '\n' + proc.stderr.decode('utf-8')
@@ -59,7 +59,7 @@ def test_packet_hdf5_tool(tmpdir, packet_hdf5_tmpfile, test_packets):
 
     # test merge
     proc = subprocess.run(
-        ['packet_hdf5_tool.py', '--merge', '-i', packet_hdf5_tmpfile, packet_hdf5_tmpfile, '-o', out_filename],
+        ['packet_hdf5_tool.py', '--merge', '-i', packet_hdf5_tmpfile, packet_hdf5_tmpfile, '-o', out_filename, '--block_size', '10'],
         capture_output=True
         )
     out = proc.stdout.decode('utf-8') + '\n' + proc.stderr.decode('utf-8')
@@ -81,7 +81,7 @@ def test_raw_hdf5_tool(tmpdir, raw_hdf5_tmpfile, test_packets):
 
     # test merge
     proc = subprocess.run(
-        ['raw_hdf5_tool.py', '--merge', '-i', raw_hdf5_tmpfile, raw_hdf5_tmpfile, '-o', out_filename],
+        ['raw_hdf5_tool.py', '--merge', '-i', raw_hdf5_tmpfile, raw_hdf5_tmpfile, '-o', out_filename, '--block_size', '10'],
         capture_output=True
         )
     out = proc.stdout.decode('utf-8') + '\n' + proc.stderr.decode('utf-8')
@@ -93,7 +93,7 @@ def test_raw_hdf5_tool(tmpdir, raw_hdf5_tmpfile, test_packets):
 
     # test merge
     proc = subprocess.run(
-        ['raw_hdf5_tool.py', '--split', '-i', out_filename, '-o', tmpdir, '--max_length', '0'],
+        ['raw_hdf5_tool.py', '--split', '-i', out_filename, '-o', tmpdir, '--max_length', '0', '--block_size', '10'],
         capture_output=True
         )
     out = proc.stdout.decode('utf-8') + '\n' + proc.stderr.decode('utf-8')

--- a/test/test_scripts.py
+++ b/test/test_scripts.py
@@ -2,6 +2,8 @@ import pytest
 import os
 import subprocess
 import sys
+import os
+_dir_ = os.path.dirname(os.path.abspath(__file__))
 
 from larpix import TimestampPacket, Packet_v2, SyncPacket, TriggerPacket
 import larpix.format.rawhdf5format as r_h5_fmt
@@ -42,8 +44,8 @@ def packet_hdf5_tmpfile(tmpdir, test_packets):
 def test_convert_rawhdf5_to_hdf5(tmpdir, raw_hdf5_tmpfile):
     out_filename = os.path.join(tmpdir, 'datalog_convert_test.h5')
     proc = subprocess.run(
-        ['python', 'convert_rawhdf5_to_hdf5.py', '-i', raw_hdf5_tmpfile, '-o', out_filename, '--block_size', '10'],
-        check=True, shell=True
+        ['python', os.path.join(_dir_,'../scripts/convert_rawhdf5_to_hdf5.py'), '-i', raw_hdf5_tmpfile, '-o', out_filename, '--block_size', '10'],
+        check=True
         )
 
     # test read from file
@@ -56,8 +58,8 @@ def test_packet_hdf5_tool(tmpdir, packet_hdf5_tmpfile, test_packets):
 
     # test merge
     proc = subprocess.run(
-        ['python', 'packet_hdf5_tool.py', '--merge', '-i', packet_hdf5_tmpfile, packet_hdf5_tmpfile, '-o', out_filename, '--block_size', '10'],
-        check=True, shell=True
+        ['python', os.path.join(_dir_,'../scripts/packet_hdf5_tool.py'), '--merge', '-i', packet_hdf5_tmpfile, packet_hdf5_tmpfile, '-o', out_filename, '--block_size', '10'],
+        check=True
         )
 
     # test read from file
@@ -72,8 +74,8 @@ def test_raw_hdf5_tool(tmpdir, raw_hdf5_tmpfile, test_packets):
 
     # test merge
     proc = subprocess.run(
-        ['python', 'raw_hdf5_tool.py', '--merge', '-i', raw_hdf5_tmpfile, raw_hdf5_tmpfile, '-o', out_filename, '--block_size', '10'],
-        check=True, shell=True
+        ['python', os.path.join(_dir_,'../scripts/raw_hdf5_tool.py'), '--merge', '-i', raw_hdf5_tmpfile, raw_hdf5_tmpfile, '-o', out_filename, '--block_size', '10'],
+        check=True
         )
 
     # test read data
@@ -81,8 +83,8 @@ def test_raw_hdf5_tool(tmpdir, raw_hdf5_tmpfile, test_packets):
 
     # test merge
     proc = subprocess.run(
-        ['python', 'raw_hdf5_tool.py', '--split', '-i', out_filename, '-o', tmpdir, '--max_length', '0', '--block_size', '10'],
-        check=True, shell=True
+        ['python', os.path.join(_dir_,'../scripts/raw_hdf5_tool.py'), '--split', '-i', out_filename, '-o', tmpdir, '--max_length', '0', '--block_size', '10'],
+        check=True
         )
 
     # test read data

--- a/test/test_scripts.py
+++ b/test/test_scripts.py
@@ -1,6 +1,7 @@
 import pytest
 import os
 import subprocess
+import sys
 
 from larpix import TimestampPacket, Packet_v2, SyncPacket, TriggerPacket
 import larpix.format.rawhdf5format as r_h5_fmt
@@ -41,10 +42,9 @@ def packet_hdf5_tmpfile(tmpdir, test_packets):
 def test_convert_rawhdf5_to_hdf5(tmpdir, raw_hdf5_tmpfile):
     out_filename = os.path.join(tmpdir, 'datalog_convert_test.h5')
     proc = subprocess.run(
-        ['convert_rawhdf5_to_hdf5.py', '-i', raw_hdf5_tmpfile, '-o', out_filename, '--block_size', '10'],
-        capture_output=True
+        ['convert_rawhdf5_to_hdf5.py', '-i', raw_hdf5_tmpfile, '-o', out_filename, '--block_size', '10']
         )
-    out = proc.stdout.decode('utf-8') + '\n' + proc.stderr.decode('utf-8')
+    out = proc.stdout.decode('utf-8') + '\n' + proc.stderr.decode('utf-8') if sys.version_info[1] == 6 else None
     assert proc.returncode == 0, \
         f'Return code: {proc.returncode}\nout: {out}'
 
@@ -59,10 +59,9 @@ def test_packet_hdf5_tool(tmpdir, packet_hdf5_tmpfile, test_packets):
 
     # test merge
     proc = subprocess.run(
-        ['packet_hdf5_tool.py', '--merge', '-i', packet_hdf5_tmpfile, packet_hdf5_tmpfile, '-o', out_filename, '--block_size', '10'],
-        capture_output=True
+        ['packet_hdf5_tool.py', '--merge', '-i', packet_hdf5_tmpfile, packet_hdf5_tmpfile, '-o', out_filename, '--block_size', '10']
         )
-    out = proc.stdout.decode('utf-8') + '\n' + proc.stderr.decode('utf-8')
+    out = proc.stdout.decode('utf-8') + '\n' + proc.stderr.decode('utf-8') if sys.version_info[1] == 6 else None
     assert proc.returncode == 0, \
         f'Return code: {proc.returncode}\nout: {out}'
 
@@ -71,8 +70,6 @@ def test_packet_hdf5_tool(tmpdir, packet_hdf5_tmpfile, test_packets):
     orig_packets += p_h5_fmt.from_file(packet_hdf5_tmpfile)['packets']
     new_packets = p_h5_fmt.from_file(out_filename)['packets']
     assert len(orig_packets) == len(new_packets)
-    print(orig_packets[:10])
-    print(new_packets[:10])
     assert orig_packets == new_packets, \
         f'Return code: {proc.returncode}\nout: {out}'
 
@@ -81,10 +78,9 @@ def test_raw_hdf5_tool(tmpdir, raw_hdf5_tmpfile, test_packets):
 
     # test merge
     proc = subprocess.run(
-        ['raw_hdf5_tool.py', '--merge', '-i', raw_hdf5_tmpfile, raw_hdf5_tmpfile, '-o', out_filename, '--block_size', '10'],
-        capture_output=True
+        ['raw_hdf5_tool.py', '--merge', '-i', raw_hdf5_tmpfile, raw_hdf5_tmpfile, '-o', out_filename, '--block_size', '10']
         )
-    out = proc.stdout.decode('utf-8') + '\n' + proc.stderr.decode('utf-8')
+    out = proc.stdout.decode('utf-8') + '\n' + proc.stderr.decode('utf-8') if sys.version_info[1] == 6 else None
     assert proc.returncode == 0, \
         f'Return code: {proc.returncode}\nout: {out}'
 
@@ -93,10 +89,9 @@ def test_raw_hdf5_tool(tmpdir, raw_hdf5_tmpfile, test_packets):
 
     # test merge
     proc = subprocess.run(
-        ['raw_hdf5_tool.py', '--split', '-i', out_filename, '-o', tmpdir, '--max_length', '0', '--block_size', '10'],
-        capture_output=True
+        ['raw_hdf5_tool.py', '--split', '-i', out_filename, '-o', tmpdir, '--max_length', '0', '--block_size', '10']
         )
-    out = proc.stdout.decode('utf-8') + '\n' + proc.stderr.decode('utf-8')
+    out = proc.stdout.decode('utf-8') + '\n' + proc.stderr.decode('utf-8') if sys.version_info[1] == 6 else None
     assert proc.returncode == 0, \
         f'Return code: {proc.returncode}\nout: {out}'
 


### PR DESCRIPTION
Adds two scripts to help manage larpix hdf5 files:
 - `raw_hdf5_tool.py`
 - `packet_hdf5_tool.py`

which are intended to be used with the corresponding file types.

Currently, I've implemented the ability to merge or split raw hdf5 files, as well as the ability to merge packet hdf5 files.

@soleti can you test `packet_hdf5_tool.py --merge` for the simulation?