### PR TITLE
Updated information from LarPix v1 to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,7 +661,8 @@ You can also view entire "columns" of data:
 # all packets' ADC counts, including non-data packets
 raw_values['dataword']
 # Select based on data type using a numpy bool / "mask" array:
-raw_values['dataword'][raw_values['packet_type'] == 1] # all data packets' ADC counts
+raw_values['dataword'][raw_values['packet_type'] == 1] # all data packets' ADC counts 
+# ==1 for v3 of the ASIC, ==0 for Any previous versions/generation
 ```
 
 ``h5py`` and ``numpy`` optimize the retrieval of data so you can read

--- a/README.md
+++ b/README.md
@@ -661,7 +661,7 @@ You can also view entire "columns" of data:
 # all packets' ADC counts, including non-data packets
 raw_values['dataword']
 # Select based on data type using a numpy bool / "mask" array:
-raw_values['dataword'][raw_values['packet_type'] == 0] # all data packets' ADC counts
+raw_values['dataword'][raw_values['packet_type'] == 1] # all data packets' ADC counts
 ```
 
 ``h5py`` and ``numpy`` optimize the retrieval of data so you can read


### PR DESCRIPTION
The ==0 in "Select based on data type using a lumpy bool/'mask' array" has been changed to ==1 because of a difference in how v1 of LArPix works and how v3 of LArPix works. Action to make this change has been verified by Jaafar.