### PR TITLE
minor/miscellaneouss v3

### DIFF
--- a/larpix/configs/chip/default_v3.json
+++ b/larpix/configs/chip/default_v3.json
@@ -81,7 +81,7 @@
         "threshold_polarity": 1,
         "reset_length": 1,
         "mark_first_packet": 1,
-        "reset_threshold": 0,
+        "reset_threshold_lsbs": 0,
         "min_delta_adc": 0,
         "digital_threshold": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
         "RESERVED": 0,

--- a/larpix/configuration/configuration_v3.py
+++ b/larpix/configuration/configuration_v3.py
@@ -11,7 +11,7 @@ from . import configuration_v2_base as v2_base
 
 class Configuration_v3(BaseConfiguration_v2):
     '''
-    Represents the desired configuration state of a LArPix v2 chip.
+    Represents the desired configuration state of a LArPix v3 chip.
 
     Each register name is available as its own attribute for inspecting and
     setting the value of the corresponding register.
@@ -204,7 +204,7 @@ _property_configuration = OrderedDict([
             (v2_base._compound_property, (['enable_dynamic_reset', 'enable_min_delta_adc', 'threshold_polarity', 'reset_length', 'mark_first_packet'], (int), 0, 7), (1363,1366))),
         ('mark_first_packet',
             (v2_base._compound_property, (['enable_dynamic_reset', 'enable_min_delta_adc', 'threshold_polarity', 'reset_length', 'mark_first_packet'], (int,bool), 0, 1), (1366,1367))),
-        ('reset_threshold',
+        ('reset_threshold_lsbs',
             (v2_base._basic_property, (int, 0, 255), (1368,1376))),
         ('min_delta_adc',
             (v2_base._basic_property, (int, 0, 255), (1376,1384))),


### PR DESCRIPTION
    Refer to ['v3' ](https://github.com/larpix/larpix-control/blob/eac6ba6a19209246a55c8a56069dc27b0b94c45c/larpix/configuration/configuration_v3.py#L14)in configuration_v3.py comments ​

    "Represents the desired configuration state of a LArPix v2 chip"​

    Match register namespace: ​

    Config table ['reset_threshold_lsbs'](https://github.com/larpix/larpix-control/blob/eac6ba6a19209246a55c8a56069dc27b0b94c45c/larpix/configuration/configuration_v3.py#L207) named 'reset_threshold' in software​

    Note: there is another register called 'reset_threshold_msbs'