### PR TITLE
Handle different packet versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ To create a permanent record of communications with the LArPix ASICs, an
 
 ```python
 from larpix.logger import HDF5Logger
-controller.logger = HDF5Logger(filename=None, buffer_length=10000) # a filename of None uses the default filename formatting
+controller.logger = HDF5Logger(filename=None, buffer_length=10000, version='2.4') # a filename of None uses the default filename formatting
 controller.logger.enable() # starts tracking all communications
 ```
 
@@ -572,7 +572,7 @@ You can also initialize and enable the logger in one call by passing the
 ``enabled`` keyword argument (which defaults to ``False``):
 
 ```
-controller.logger = HDF5Logger(filename=None, enabled=True)
+controller.logger = HDF5Logger(filename=None, version='2.4', enabled=True)
 ```
 
 Now whenever you send or receive packets, they will be captured by the logger

--- a/examples/v2_manual_bringup.py
+++ b/examples/v2_manual_bringup.py
@@ -4,7 +4,7 @@ from larpix.io import PACMAN_IO
 ctl = Controller()
 
 # Bring up communications with io group
-ctl.io = PACMAN_IO('io/manual_io.json') # specifies ip addresses + etc for io group
+ctl.io = PACMAN_IO('io/manual_io.json', asic_version=2) # specifies ip addresses + etc for io group
 ctl.io.ping()
 
 # Load network configuration

--- a/examples/v2_production_bringup.py
+++ b/examples/v2_production_bringup.py
@@ -4,7 +4,7 @@ from larpix.io import PACMAN_IO
 ctl = Controller()
 
 # Bring up communications with io groups
-ctl.io = PACMAN_IO('io/production_io.json') # specifies ip addresses + etc for io groups
+ctl.io = PACMAN_IO('io/production_io.json', asic_version=2) # specifies ip addresses + etc for io groups
 if not ctl.io.ping():
     raise RuntimeError
 

--- a/examples/v2_testing_bringup.py
+++ b/examples/v2_testing_bringup.py
@@ -4,7 +4,7 @@ from larpix.io import PACMAN_IO
 ctl = Controller()
 
 # Bring up communications with io groups
-ctl.io = PACMAN_IO('io/testing_io.json') # specifies ip addresses + etc for io groups
+ctl.io = PACMAN_IO('io/testing_io.json', asic_version=2) # specifies ip addresses + etc for io groups
 if not ctl.io.ping():
     raise RuntimeError
 

--- a/larpix/controller.py
+++ b/larpix/controller.py
@@ -862,10 +862,14 @@ class Controller(object):
             packets += parent_chip.get_configuration_write_packets(
                 registers=parent_chip.config.register_map[self._enable_piso_upstream[parent_chip.asic_version]])
             if parent_chip.asic_version in ('2b', '2d', 3):
-                setattr(parent_chip.config, f'i_tx_diff{parent_uart}', i_tx_diff)
-                setattr(parent_chip.config, f'tx_slices{parent_uart}', tx_slices)
-                registers = list(parent_chip.config.register_map[f'i_tx_diff{parent_uart}']) + list(parent_chip.config.register_map[f'tx_slices{parent_uart}'])
-                packets += parent_chip.get_configuration_write_packets(registers=registers)
+                setattr(parent_chip.config,
+                        f'i_tx_diff{parent_uart}', i_tx_diff)
+                setattr(parent_chip.config,
+                        f'tx_slices{parent_uart}', tx_slices)
+                registers = list(parent_chip.config.register_map[f'i_tx_diff{parent_uart}']) + list(
+                    parent_chip.config.register_map[f'tx_slices{parent_uart}'])
+                packets += parent_chip.get_configuration_write_packets(
+                    registers=registers)
 
             for mosi_link in subnetwork['mosi'].in_edges(parent_chip_id):
                 mosi_uart = subnetwork['mosi'].edges[mosi_link]['uart']
@@ -899,7 +903,7 @@ class Controller(object):
                     ds_uart] = 1
             packets += chip.get_configuration_write_packets(
                 registers=chip.config.register_map[self._enable_piso_downstream[chip.asic_version]])
-            if chip.asic_version in ('2b','2d', 3):
+            if chip.asic_version in ('2b', '2d', 3):
                 setattr(chip.config, f'i_tx_diff{ds_uart}', i_tx_diff)
                 setattr(chip.config, f'tx_slices{ds_uart}', tx_slices)
                 registers = list(chip.config.register_map[f'i_tx_diff{ds_uart}']) + list(
@@ -1393,7 +1397,7 @@ class Controller(object):
         for packet in self.reads[-1]:
             packet_key = packet.chip_key
             if (hasattr(packet, 'CONFIG_READ_PACKET') and packet.packet_type == packet.CONFIG_READ_PACKET) and packet.has_valid_parity():
-                #print(packet)
+                # print(packet)
                 register_address = packet.register_address
                 if packet_key in configuration_data and register_address in configuration_data[packet_key]:
                     configuration_data[packet_key][register_address] = (

--- a/larpix/format/hdf5format.py
+++ b/larpix/format/hdf5format.py
@@ -357,6 +357,11 @@ _max_config_registers = Configuration_Lightpix_v1.num_registers
 #: The most recent / up-to-date LArPix+HDF5 format version
 latest_version = '3.0'
 
+_FORMAT_VERSION_REQUIRED_MSG = (
+    'Format version is required. Pass version explicitly (for example version="2.4" or version="3.0"). '
+    'CLI users should pass --format-version.'
+)
+
 #: The dtype specification used in the HDF5 files.
 #:
 #: Structure: ``{version: {dset_name: [structured dtype fields]}}``
@@ -1041,23 +1046,27 @@ def _encode_packet(packet, version, packet_dset_name):
             if encoded_packet[idx] is None:
                 encoded_packet[idx] = 0
         return(tuple(encoded_packet))
-    return False
+    raise ValueError(
+        'Unsupported packet class {} for format version {} dataset {}. '
+        'Choose a compatible format version or convert packet types before writing.'.format(
+            packet.__class__.__name__, version, packet_dset_name
+        )
+    )
 
 def init_file(f: h5py.File, version=None, chip_list=None):
     message_dset, configs_dset = None, None
 
+    if version is None:
+        raise ValueError(_FORMAT_VERSION_REQUIRED_MSG)
+
     if "_header" not in f.keys():
         header = f.create_group("_header")
-        if version is None:
-            version = latest_version
         header.attrs["version"] = version
         header.attrs["created"] = time.time()
     else:
         header = f["_header"]
         file_version = header.attrs["version"]
-        if version is None:
-            version = file_version
-        elif file_version != version:
+        if file_version != version:
             raise RuntimeError(
                 "Incompatible versions: existing: %s, "
                 "specified: %s" % (file_version, version)
@@ -1129,6 +1138,8 @@ def to_file(filename, packet_list=None, chip_list=None, mode='a', version=None, 
     '''
     if packet_list is None: packet_list = []
     if chip_list is None: chip_list = []
+    if version is None:
+        raise ValueError(_FORMAT_VERSION_REQUIRED_MSG)
     if workers is None:
       workers = max(min(os.cpu_count(), int(len(packet_list)//10000)),1)
 
@@ -1194,9 +1205,9 @@ def to_file(filename, packet_list=None, chip_list=None, mode='a', version=None, 
         if workers > 1:
             packet_args = zip(packet_list, [version]*len(packet_list), [packet_dset_name]*len(packet_list))
             with multiprocessing.Pool(workers) as p:
-                encoded_packets = list(filter(bool, p.starmap(_encode_packet, packet_args)))
+                encoded_packets = list(p.starmap(_encode_packet, packet_args))
         else:
-            encoded_packets = list(filter(bool, [_encode_packet(packet, version, packet_dset_name) for packet in packet_list]))
+            encoded_packets = [_encode_packet(packet, version, packet_dset_name) for packet in packet_list]
 
         if message_dset:
             message_dset_name = message_dset.name.removeprefix('/')
@@ -1239,11 +1250,12 @@ def from_file(filename, version=None, start=None, end=None, load_configs=None):
         ``'version'``, containing the file metadata.
 
     '''
+    if version is None:
+        raise ValueError(_FORMAT_VERSION_REQUIRED_MSG)
+
     with h5py.File(filename, 'r') as f:
         file_version = f['_header'].attrs['version']
-        if version is None:
-            version = file_version
-        elif version[0] == '~':
+        if version[0] == '~':
             file_major, _, file_minor = file_version.split('.')
             version_major, _, version_minor = version.split('.')
             version_major = version_major[1:]

--- a/larpix/format/hdf5format.py
+++ b/larpix/format/hdf5format.py
@@ -880,6 +880,8 @@ def _format_configs_chip_v2_4(chip, version='2.4', dset='configs', timestamp=0, 
     return row
 
 def _parse_configs_v2_4(row, asic_version, *args, **kwargs):
+    if isinstance(asic_version, bytes):
+        asic_version = asic_version.decode()
     key = Key(row['io_group'],row['io_channel'],row['chip_id'])
     if asic_version in ('1','2', '3'):
         c = Chip(key,version=int(asic_version))
@@ -890,7 +892,7 @@ def _parse_configs_v2_4(row, asic_version, *args, **kwargs):
         d[i] = row['registers'][i]
     endian = 'big' if asic_version == '1' else 'little'
     c.config.from_dict_registers(d, endian=endian)
-    return 
+    return c
 
 
 def _format_configs_chip_v3_0(chip, version='3.0', dset='configs', timestamp=0, *args, **kwargs):

--- a/larpix/format/hdf5format_direct.py
+++ b/larpix/format/hdf5format_direct.py
@@ -6,9 +6,48 @@ import numpy as np
 
 from .hdf5format import dtypes, init_file
 
-VERSION = "2.4"
-DTYPE = dtypes[VERSION]["packets"]
+DEFAULT_DIRECT_VERSION = "2.4"
 BUFSIZE = 100000
+
+
+def _require_direct_versions(asic_version, version):
+    asic_msg = (
+        'ASIC version is required.\n'
+        '\tUse asic_version=2 for LArPix-v2\n'
+        '\tUse asic_version=3 for LArPix-v3\n'
+        '\tExample: to_file_direct(..., asic_version=2, version="2.4")\n'
+        'For CLI conversion, pass --asic-version {2,3}.'
+    )
+    format_msg = (
+        'Format version is required.\n'
+        '\tUse format_version="2.4" for typical LArPix-v2 data\n'
+        '\tUse format_version="3.0" for typical LArPix-v3 data\n'
+        '\tExample: to_file_direct(..., asic_version=2, version="2.4")\n'
+        'For CLI conversion, pass --format-version.'
+    )
+    if asic_version is None:
+        raise ValueError(asic_msg)
+    if version is None:
+        raise ValueError(format_msg)
+    try:
+        asic_version = int(asic_version)
+    except (TypeError, ValueError):
+        raise ValueError(asic_msg)
+    if asic_version not in (2, 3):
+        raise ValueError(asic_msg)
+
+    if asic_version == 2 and version != "2.4":
+        raise ValueError(
+            'Direct conversion currently supports ASIC v2 only with format version="2.4". '
+            'Set version="2.4", or use non-direct conversion for other format versions.'
+        )
+    if asic_version == 3:
+        raise ValueError(
+            'Direct conversion does not support ASIC v3 packet decoding yet. '
+            'Use non-direct conversion (without --direct) and pass asic_version=3 to the parser.'
+        )
+
+    return asic_version, version
 
 
 @numba.njit
@@ -142,9 +181,12 @@ def parse_msg(msg: np.array, packets: np.array, io_group=0) -> int:
     return npackets
 
 
-def to_file_direct(filename, msg_list=[], io_groups=[], chip_list=[], mode="a"):
+def to_file_direct(filename, msg_list=[], io_groups=[], chip_list=[], mode="a", asic_version=None, version=None):
+    _require_direct_versions(asic_version, version)
+    dtype = dtypes[version]["packets"]
+
     with h5py.File(filename, mode) as f:
-        init_file(f, VERSION, chip_list)
+        init_file(f, version, chip_list)
 
         packet_dset_name = "packets"
         if packet_dset_name not in f.keys():
@@ -152,14 +194,14 @@ def to_file_direct(filename, msg_list=[], io_groups=[], chip_list=[], mode="a"):
                 packet_dset_name,
                 shape=(0,),
                 maxshape=(None,),
-                dtype=DTYPE,
+                dtype=dtype,
             )
             start_index = 0
         else:
             packet_dset = f[packet_dset_name]
             start_index = packet_dset.shape[0]
 
-        packets = np.zeros(shape=(2*BUFSIZE,), dtype=DTYPE)
+        packets = np.zeros(shape=(2*BUFSIZE,), dtype=dtype)
         npackets = 0
 
         def write():

--- a/larpix/format/message_format.py
+++ b/larpix/format/message_format.py
@@ -9,7 +9,25 @@ with larpix-control:
 import warnings
 import struct
 
-from larpix.larpix import Packet, TimestampPacket, Packet_v1, Packet_v2
+from larpix.larpix import Packet, TimestampPacket, Packet_v1, Packet_v2, Packet_v3
+
+
+def _require_decode_asic_version(asic_version):
+    msg = (
+        'ASIC version is required for dataserver message decoding.\n'
+        '\tUse asic_version=2 for LArPix-v2\n'
+        '\tUse asic_version=3 for LArPix-v3\n'
+        '\tExample: dataserver_message_decode(..., asic_version=2)'
+    )
+    if asic_version is None:
+        raise ValueError(msg)
+    try:
+        asic_version = int(asic_version)
+    except (TypeError, ValueError):
+        raise ValueError(msg)
+    if asic_version not in (2, 3):
+        raise ValueError(msg)
+    return asic_version
 
 def dataserver_message_encode(packets, version=(1,0)):
     r'''
@@ -83,12 +101,12 @@ def dataserver_message_encode(packets, version=(1,0)):
         msgs += [msg]
     return msgs
 
-def dataserver_message_decode(msgs, version=(1,0), **kwargs):
+def dataserver_message_decode(msgs, version=(1,0), asic_version=None, **kwargs):
     r'''
     Convert a list of larpix data server messages into packets. Additional packet meta data can be passed along via kwargs E.g.::
 
         msg = b'\x01\x00D\x01\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00'
-        packets = dataserver_message_decode([msg], io_group=1)
+        packets = dataserver_message_decode([msg], io_group=1, asic_version=2)
         packets[0] # Packet(b'\x04\x00\x00\x00\x00\x00\x00'), key of '1-1-1'
 
     :param msgs: list of bytestream messages each starting with a single 8-byte header word, followed by N 8-byte data words
@@ -99,6 +117,8 @@ def dataserver_message_decode(msgs, version=(1,0), **kwargs):
 
     '''
     packets = []
+    asic_version = _require_decode_asic_version(asic_version)
+    packet_cls = Packet_v2 if asic_version == 2 else Packet_v3
     for msg in msgs:
         major, minor = struct.unpack('BB',msg[:2])
         if (major, minor) != version:
@@ -118,8 +138,8 @@ def dataserver_message_decode(msgs, version=(1,0), **kwargs):
                     packet_bytes = payload[start_index:start_index+8]
                     if Packet == Packet_v1:
                         packets.append(Packet(packet_bytes[:-1]))
-                    elif Packet == Packet_v2:
-                        packets.append(Packet(packet_bytes))
+                    else:
+                        packets.append(packet_cls(packet_bytes))
                     packets[-1].io_channel = io_chain
                     if kwargs:
                         for key,value in kwargs.items():

--- a/larpix/format/pacman_msg_format.py
+++ b/larpix/format/pacman_msg_format.py
@@ -32,13 +32,14 @@ E.g.::
     msg = pacman_msg_fmt.format_msg(*data) # b'D----\x00\x01\x00D\x01\x00\x00\x00\x00\x00\x00datadata'
 
 To facilitate translating to/from ``larpix-control`` packet objects, you can use
-the ``format(pkts, msg_type)`` and ``parse(msg, io_group=None)`` methods. E.g.::
+the ``format(pkts, msg_type, asic_version=...)`` and
+``parse(msg, io_group=None, asic_version=...)`` methods. E.g.::
 
     packet = Packet_v2()
     packet.io_channel = 1
-    msg = pacman_msg_fmt.format([packet]) # b'?----\x00\x01\x00D\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+    msg = pacman_msg_fmt.format([packet], asic_version=2) # b'?----\x00\x01\x00D\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
-    packets = pacman_msg_fmt.parse(msg, io_group=1) # [Packet_v2(b'\x00\x00\x00\x00\x00\x00\x00\x00')]
+    packets = pacman_msg_fmt.parse(msg, io_group=1, asic_version=2) # [Packet_v2(b'\x00\x00\x00\x00\x00\x00\x00\x00')]
     packets[0].io_group # 1
 
 Note that no ``io_group`` data is contained within a pacman message. This means
@@ -53,13 +54,32 @@ import time
 
 from larpix import Packet_v2, Packet_v3, TriggerPacket, SyncPacket, TimestampPacket
 
-_use_pkt_version = 2
-
 _pkt_versions = {
     
     2 : Packet_v2,
     3 : Packet_v3
 }
+
+_ASIC_VERSION_REQUIRED_MSG = (
+    'ASIC version is required.\n'
+    '\tUse asic_version=2 for LArPix-v2\n'
+    '\tUse asic_version=3 for LArPix-v3\n'
+    '\tExample: parse(msg, io_group=1, asic_version=2)\n'
+    'For PACMAN_IO, set asic_version in the constructor.\n'
+    'For CLI conversion, pass --asic-version {2,3}.'
+)
+
+
+def _require_asic_version(asic_version):
+    if asic_version is None:
+        raise ValueError(_ASIC_VERSION_REQUIRED_MSG)
+    try:
+        asic_version = int(asic_version)
+    except (TypeError, ValueError):
+        raise ValueError(_ASIC_VERSION_REQUIRED_MSG)
+    if asic_version not in _pkt_versions:
+        raise ValueError(_ASIC_VERSION_REQUIRED_MSG)
+    return asic_version
 
 
 #: Most up-to-date message format version.
@@ -202,16 +222,16 @@ def parse_msg(msg):
 def _replace_none(obj, attr, default=0):
     return getattr(obj, attr) if getattr(obj, attr) is not None else default
 
-def _packet_data_req(pkt, *args):
-    _use_pkt_type = _pkt_versions[_use_pkt_version]
+def _packet_data_req(pkt, ts_pacman, asic_version):
+    _use_pkt_type = _pkt_versions[asic_version]
     if isinstance(pkt, _use_pkt_type):
         return ('TX',
                 _replace_none(pkt,'io_channel'),
                 pkt.bytes())
     return tuple()
 
-def _packet_data_data(pkt, ts_pacman, *args):
-    _use_pkt_type = _pkt_versions[_use_pkt_version]
+def _packet_data_data(pkt, ts_pacman, asic_version):
+    _use_pkt_type = _pkt_versions[asic_version]
     if isinstance(pkt, _use_pkt_type):
         return ('DATA',
                 _replace_none(pkt,'io_channel'),
@@ -228,7 +248,7 @@ def _packet_data_data(pkt, ts_pacman, *args):
                 _replace_none(pkt,'timestamp'))
     return tuple()
 
-def format(packets, msg_type='REQ', ts_pacman=0):
+def format(packets, msg_type='REQ', ts_pacman=0, asic_version=None):
     '''
     Converts larpix packets into a single PACMAN message.
     The message header is automatically generated.
@@ -236,18 +256,20 @@ def format(packets, msg_type='REQ', ts_pacman=0):
     Note:: For request messages, this method only formats ``Packet_v2`` objects. For data messages, this method only formats ``Packet_v2``, ``SyncPacket``, and ``TriggerPacket`` objects.
 
     '''
+    asic_version = _require_asic_version(asic_version)
+
     get_data = _packet_data_req
     if msg_type == 'DATA':
         get_data = _packet_data_data
 
     word_datas = list()
     for packet in packets:
-        word_data = get_data(packet, ts_pacman)
+        word_data = get_data(packet, ts_pacman, asic_version)
         if len(word_data) == 0: continue
         word_datas.append(word_data)
     return format_msg(msg_type, word_datas)
 
-def parse(msg, io_group=None):
+def parse(msg, io_group=None, asic_version=None):
     '''
     Converts a PACMAN message into larpix packets
 
@@ -257,7 +279,8 @@ def parse(msg, io_group=None):
     and sync words are parsed into ``SyncPacket`` objects.
 
     '''
-    _use_pkt_type = _pkt_versions[_use_pkt_version]
+    asic_version = _require_asic_version(asic_version)
+    _use_pkt_type = _pkt_versions[asic_version]
     packets = list()
     header, word_datas = parse_msg(msg)
     packets.append(TimestampPacket(timestamp=header[1]))

--- a/larpix/format/rawhdf5format.py
+++ b/larpix/format/rawhdf5format.py
@@ -90,8 +90,8 @@ case, to convert to the standard ``larpix.format.hdf5format``::
     rd = from_rawfile('raw.h5')
     pkts = list()
     for io_group,msg in zip(rd['msg_headers']['io_groups'], rd['msgs']):
-        pkts.extend(parse(msg, io_group=io_group))
-    to_file('new_filename.h5', packet_list=pkts)
+        pkts.extend(parse(msg, io_group=io_group, asic_version=2))
+    to_file('new_filename.h5', packet_list=pkts, version='2.4')
 
 but as always, the most efficient means of accessing the data is to operate on
 the data itself, rather than converting between types.

--- a/larpix/io/fakeio.py
+++ b/larpix/io/fakeio.py
@@ -79,7 +79,7 @@ class FakeIO(IO):
         for position, timestamp in reversed(list(zip(positions, timestamps))):
             packets.insert(position, TimestampPacket(timestamp))
 
-    def send(self, packets):
+    def send(self, packets, msg_length=None):
         '''
         Print the packets to stdout.
 

--- a/larpix/io/io.py
+++ b/larpix/io/io.py
@@ -60,11 +60,12 @@ class IO(object):
         '''
         pass
 
-    def send(self, packets):
+    def send(self, packets, msg_length=None):
         '''
         Function for sending larpix packet objects
 
         :param packets: ``list`` of larpix ``Packet`` objects to send via IO
+        :param msg_length: optional maximum packets per transport message
 
         :returns: ``None``
 

--- a/larpix/io/multizmq_io.py
+++ b/larpix/io/multizmq_io.py
@@ -79,7 +79,7 @@ class MultiZMQ_IO(IO):
     def sender_replies(self, val):
         self._sender_replies = val
 
-    def send(self, packets):
+    def send(self, packets, msg_length=None):
         self.sender_replies = defaultdict(list)
         send_time = time.time()
         addresses = [self._io_group_table[packet.io_group] for packet in packets]

--- a/larpix/io/multizmq_io.py
+++ b/larpix/io/multizmq_io.py
@@ -26,8 +26,22 @@ class MultiZMQ_IO(IO):
     '''
     _valid_config_classes = ['MultiZMQ_IO']
 
-    def __init__(self, config_filepath=None, miso_map=None, mosi_map=None):
+    def __init__(self, config_filepath=None, miso_map=None, mosi_map=None, asic_version=None):
         super(MultiZMQ_IO, self).__init__()
+        asic_msg = (
+            'ASIC version is required when constructing MultiZMQ_IO.\n'
+            '\tUse asic_version=2 for LArPix-v2\n'
+            '\tUse asic_version=3 for LArPix-v3\n'
+            '\tExample: MultiZMQ_IO(..., asic_version=2)'
+        )
+        if asic_version is None:
+            raise ValueError(asic_msg)
+        try:
+            self.asic_version = int(asic_version)
+        except (TypeError, ValueError):
+            raise ValueError(asic_msg)
+        if self.asic_version not in (2, 3):
+            raise ValueError(asic_msg)
         self.load(config_filepath)
 
         if miso_map is None:
@@ -94,7 +108,13 @@ class MultiZMQ_IO(IO):
         Convert a list ZMQ messages into packets
 
         '''
-        return_packets = dataserver_message_decode(msgs, version=(1,0), io_group=self._io_group_table.inv[address], **kwargs)
+        return_packets = dataserver_message_decode(
+            msgs,
+            version=(1,0),
+            asic_version=self.asic_version,
+            io_group=self._io_group_table.inv[address],
+            **kwargs
+        )
         if self._miso_map.keys():
             for packet in return_packets:
                 if hasattr(packet, 'io_channel') and packet.io_channel in self._miso_map.keys():

--- a/larpix/io/pacman_io.py
+++ b/larpix/io/pacman_io.py
@@ -15,7 +15,6 @@ from larpix.io import IO
 from larpix.configs import load
 import larpix.format.pacman_msg_format as pacman_msg_format
 import larpix.format.rawhdf5format as rawhdf5format
-import larpix.format
 
 class PACMAN_IO(IO):
     '''
@@ -80,9 +79,25 @@ class PACMAN_IO(IO):
     _adc2mv = lambda _,x: ((x >> 16) >> 3) * 4
     _adc2ma = lambda _,x: ((x >> 16) - (x >> 31) * 65535) * 500 * 0.01
 
-    def __init__(self, config_filepath=None, hwm=20000, relaxed=True, timeout=-1, raw_directory='./', raw_filename=None, asic_version=2):
+    def __init__(self, config_filepath=None, hwm=20000, relaxed=True, timeout=-1, raw_directory='./', raw_filename=None, asic_version=None):
         super(PACMAN_IO, self).__init__()
         self.load(config_filepath)
+
+        asic_msg = (
+            'ASIC version is required when constructing PACMAN_IO.\n'
+            '\tUse asic_version=2 for LArPix-v2\n'
+            '\tUse asic_version=3 for LArPix-v3\n'
+            '\tExample: PACMAN_IO(..., asic_version=2)'
+        )
+
+        if asic_version is None:
+            raise ValueError(asic_msg)
+        try:
+            self.asic_version = int(asic_version)
+        except (TypeError, ValueError):
+            raise ValueError(asic_msg)
+        if self.asic_version not in (2, 3):
+            raise ValueError(asic_msg)
 
         self.context = zmq.Context()
         self.senders = bidict.bidict()
@@ -119,8 +134,6 @@ class PACMAN_IO(IO):
             raw_filename if raw_filename is not None \
                 else time.strftime(self.default_raw_filename_fmt)
         )
-
-        larpix.format.pacman_msg_format._use_pkt_version = asic_version
 
         self._launch_raw_file_worker()
 
@@ -163,7 +176,11 @@ class PACMAN_IO(IO):
             io_group = packets[0].io_group
             for i in range(0, len(packets), self.max_msg_length):
                 msg_len = min(len(packets)-i, self.max_msg_length)
-                msg = pacman_msg_format.format(packets[i:i+msg_len], msg_type='REQ')
+                msg = pacman_msg_format.format(
+                    packets[i:i+msg_len],
+                    msg_type='REQ',
+                    asic_version=self.asic_version
+                )
                 address = self._io_group_table[io_group]
                 self.senders[address].send(msg)
                 self._sender_replies[address].append(self.senders[address].recv())
@@ -244,7 +261,11 @@ class PACMAN_IO(IO):
                     address_list += [self.receivers.inv[socket]]
         if not self.disable_packet_parsing:
             for message, address in zip(bytestream_list, address_list):
-                packets += pacman_msg_format.parse(message, io_group=self._io_group_table.inv[address])
+                packets += pacman_msg_format.parse(
+                    message,
+                    io_group=self._io_group_table.inv[address],
+                    asic_version=self.asic_version
+                )
             bytestream = b''.join(bytestream_list)
         if self.enable_raw_file_writing:
             self._raw_file_queue.put((bytestream_list, [self._io_group_table.inv[address] for address in address_list]))

--- a/larpix/io/pacman_io.py
+++ b/larpix/io/pacman_io.py
@@ -138,12 +138,19 @@ class PACMAN_IO(IO):
 
         self._launch_raw_file_worker()
 
-    def send(self, packets, msg_length=max_msg_length):
+    def send(self, packets, msg_length=None):
         '''
         Sends a request message to PACMAN boards to send designated
         packets.
 
         '''
+        if msg_length is None:
+            msg_length = self.max_msg_length
+        else:
+            msg_length = int(msg_length)
+            if msg_length <= 0:
+                raise ValueError('msg_length must be a positive integer')
+
         msg_packets = list()
         # group packets into messages destined for a single io group (otherwise 1pkt = 1msg)
         if self.group_packets_by_io_group:
@@ -178,7 +185,10 @@ class PACMAN_IO(IO):
                 # for packet in packets: print(packet)
                 msg_len = min(len(packets)-i, msg_length)
                 msg = pacman_msg_format.format(
-                    packets[i:i+msg_len], msg_type='REQ')
+                    packets[i:i+msg_len],
+                    msg_type='REQ',
+                    asic_version=self.asic_version
+                )
                 address = self._io_group_table[io_group]
                 self.senders[address].send(msg)
                 self._sender_replies[address].append(

--- a/larpix/io/serialport.py
+++ b/larpix/io/serialport.py
@@ -148,7 +148,7 @@ class SerialPort(IO):
             return False
         return True
 
-    def send(self, packets):
+    def send(self, packets, msg_length=None):
         '''
         Format the packets as a bytestream and send it to the FPGA and on
         to the LArPix ASICs.

--- a/larpix/logger/h5_logger.py
+++ b/larpix/logger/h5_logger.py
@@ -12,7 +12,13 @@ import h5py
 
 from larpix.logger import Logger
 from larpix import Packet, TimestampPacket, Packet_v1, Packet_v2, Packet_v3, SyncPacket, TriggerPacket
-from larpix.format.hdf5format import to_file, latest_version
+from larpix.format.hdf5format import to_file
+
+
+_FORMAT_VERSION_REQUIRED_MSG = (
+    'Format version is required when constructing HDF5Logger.\n'
+    '\tExample: HDF5Logger(..., version="2.4")'
+)
 
 class HDF5Logger(Logger):
     '''
@@ -34,8 +40,7 @@ class HDF5Logger(Logger):
         buffer to the file (optional, default: ``10000``)
     :param directory: the directory to save the data in (optional,
         default: '')
-    :param version: the format version of LArPix+HDF5 to use (optional,
-        default: ``larpix.format.hdf5format.latest_version``)
+    :param version: the format version of LArPix+HDF5 to use (required)
 
     '''
     data_desc_map = {
@@ -48,8 +53,10 @@ class HDF5Logger(Logger):
     }
 
     def __init__(self, filename=None, buffer_length=10000,
-            directory='', version=latest_version, enabled=False):
+            directory='', version=None, enabled=False):
         super(HDF5Logger, self).__init__(enabled=enabled)
+        if version is None:
+            raise ValueError(_FORMAT_VERSION_REQUIRED_MSG)
         self.version = version
         self.filename = filename
         self.directory = directory

--- a/scripts/convert_rawhdf5_to_hdf5.py
+++ b/scripts/convert_rawhdf5_to_hdf5.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import os
 import time
 
 import h5py
@@ -14,12 +15,19 @@ from larpix.format.pacman_msg_format import parse
 from larpix.format.hdf5format import to_file
 from larpix.format.hdf5format_direct import to_file_direct
 
-def main(input_filename, output_filename, block_size, direct, max_blocks):
+def main(input_filename, output_filename, block_size, direct, max_blocks, asic_version, format_version):
+    if os.path.exists(output_filename):
+        raise RuntimeError(
+            'Output file already exists: {}\n'
+            '\tChoose a new output filename or remove the existing file first.'.format(output_filename)
+        )
+
     total_messages = len_rawfile(input_filename)
     total_blocks = total_messages // block_size + 1
     if max_blocks != -1:
         total_blocks = min(max_blocks, total_blocks)
     last = time.time()
+    write_mode = 'w'
     for i_block in range(total_blocks):
         start = i_block * block_size
         end = min(start + block_size, total_messages)
@@ -30,13 +38,23 @@ def main(input_filename, output_filename, block_size, direct, max_blocks):
             last = time.time()
         rd = from_rawfile(input_filename, start=start, end=end)
         if direct:
-            to_file_direct(output_filename, rd['msgs'], rd['msg_headers']['io_groups'])
+            to_file_direct(
+                output_filename,
+                rd['msgs'],
+                rd['msg_headers']['io_groups'],
+                mode=write_mode,
+                asic_version=asic_version,
+                version=format_version
+            )
         else:
             pkts = list()
             for i_msg,data in enumerate(zip(rd['msg_headers']['io_groups'], rd['msgs'])):
                 io_group,msg = data
-                pkts.extend(parse(msg, io_group=io_group))
-            to_file(output_filename, packet_list=pkts)
+                pkts.extend(parse(msg, io_group=io_group, asic_version=asic_version))
+            to_file(output_filename, packet_list=pkts, mode=write_mode, version=format_version)
+
+        # Truncate/create the destination file only once, then append chunks.
+        write_mode = 'a'
 
     # Copy the embedded ASIC config tarball, if it exists
     with h5py.File(input_filename) as f_in:
@@ -54,5 +72,7 @@ if __name__ == '__main__':
     parser.add_argument('--block_size', default=10240, type=int, help='''Max number of messages to store in working memory (default=%(default)s)''')
     parser.add_argument('--direct', action='store_true', help='Enable direct conversion (experimental)')
     parser.add_argument('--max_blocks', type=int, default=-1)
+    parser.add_argument('--asic-version', type=int, required=True, choices=(2,3), help='ASIC packet version used to decode PACMAN binary packets (LArPix-v2: 2, LArPix-v3: 3)')
+    parser.add_argument('--format-version', type=str, required=True, help='LArPix HDF5 packet format version to write (recommended pairs: v2 -> 2.4, v3 -> 3.0)')
     args = parser.parse_args()
     c = main(**vars(args))

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -208,6 +208,7 @@ def test_controller_init(network_controller_old, network_controller_new):
         chip_id_config_packet = c['1-1-3'].get_configuration_write_packets(
             registers=c['1-1-3'].config.register_map['chip_id'])[0]
         chip_id_config_packet.chip_id = 1
+        chip_id_config_packet.assign_parity()
         if c['1-1-3'].asic_version == 2:
             assert c.io.sent[-1][-3] == chip_id_config_packet
             assert c.io.sent[-1][-4] == c['1-1-2'].get_configuration_write_packets(

--- a/test/test_format_pacman_msg_format.py
+++ b/test/test_format_pacman_msg_format.py
@@ -40,9 +40,9 @@ def test_packets():
     packets.append(SyncPacket(timestamp=123456, sync_type=b'H', clk_source=1))
     packets.append(TriggerPacket(timestamp=123456, trigger_type=b'\x01'))
 
-    msg = format(packets, msg_type='DATA')
+    msg = format(packets, msg_type='DATA', asic_version=2)
     print(msg)
-    new_packets = parse(msg)
+    new_packets = parse(msg, asic_version=2)
 
     assert packets[1:] == new_packets[1:]
     assert isinstance(new_packets[0], TimestampPacket)

--- a/test/test_h5_logger.py
+++ b/test/test_h5_logger.py
@@ -11,7 +11,7 @@ from larpix.io.fakeio import FakeIO
 from larpix.logger.h5_logger import HDF5Logger
 
 def test_enable(tmpdir):
-    logger = HDF5Logger(directory=str(tmpdir))
+    logger = HDF5Logger(directory=str(tmpdir), version='2.4')
     assert not logger.is_enabled()
     logger.record([Packet_v2()])
     assert len(logger._buffer['packets']) == 0
@@ -21,7 +21,7 @@ def test_enable(tmpdir):
     assert len(logger._buffer['packets']) == 1
 
 def test_disable(tmpdir):
-    logger =HDF5Logger(directory=str(tmpdir), enabled=True)
+    logger =HDF5Logger(directory=str(tmpdir), version='2.4', enabled=True)
     logger.disable()
     assert not logger.is_enabled()
     logger.record([Packet_v2()])
@@ -29,7 +29,7 @@ def test_disable(tmpdir):
 
 def test_flush(tmpdir):
     logger = HDF5Logger(directory=str(tmpdir), buffer_length=5,
-            enabled=True)
+            version='2.4', enabled=True)
     logger.record([Packet_v2()])
     assert len(logger._buffer['packets']) == 1
     logger.flush()
@@ -40,7 +40,7 @@ def test_flush(tmpdir):
     assert len(logger._buffer['packets']) == 0
 
 def test_record(tmpdir):
-    logger = HDF5Logger(directory=str(tmpdir), enabled=True)
+    logger = HDF5Logger(directory=str(tmpdir), version='2.4', enabled=True)
     logger.record([Packet_v2()])
     assert len(logger._buffer['packets']) == 1
     logger.record([TimestampPacket(timestamp=123)])
@@ -49,7 +49,7 @@ def test_record(tmpdir):
 @pytest.mark.filterwarnings("ignore:no IO object")
 def test_controller_write_capture(tmpdir, chip):
     controller = Controller()
-    controller.logger = HDF5Logger(directory=str(tmpdir), buffer_length=1)
+    controller.logger = HDF5Logger(directory=str(tmpdir), buffer_length=1, version='2.4')
     controller.logger.enable()
     controller.chips[chip.chip_key] = chip
     controller.write_configuration(chip.chip_key, 0)
@@ -60,7 +60,7 @@ def test_controller_read_capture(tmpdir):
     controller = Controller()
     controller.io = FakeIO()
     controller.io.queue.append(([Packet_v2()], b'\x00\x00'))
-    controller.logger = HDF5Logger(directory=str(tmpdir), buffer_length=1)
+    controller.logger = HDF5Logger(directory=str(tmpdir), buffer_length=1, version='2.4')
     controller.logger.enable()
     controller.run(0.1,'test')
     assert len(controller.logger._buffer['packets']) == 1

--- a/test/test_hdf5format.py
+++ b/test/test_hdf5format.py
@@ -266,7 +266,7 @@ def test_from_file_v1_0_many_packets(tmpfile, data_packet,
     packets = [data_packet, config_read_packet, timestamp_packet,
             message_packet]
     to_file(tmpfile, packets, version='1.0')
-    new_packets_dict = from_file(tmpfile)
+    new_packets_dict = from_file(tmpfile, version='1.0')
     assert new_packets_dict['created']
     assert new_packets_dict['version']
     assert new_packets_dict['modified']
@@ -363,7 +363,7 @@ def test_from_file_v2_0_many_packets(tmpfile, data_packet_v2,
     packets = [data_packet_v2, config_read_packet_v2, timestamp_packet,
             message_packet]
     to_file(tmpfile, packets, version='2.0')
-    new_packets_dict = from_file(tmpfile)
+    new_packets_dict = from_file(tmpfile, version='2.0')
     assert new_packets_dict['created']
     assert new_packets_dict['version']
     assert new_packets_dict['modified']
@@ -391,7 +391,7 @@ def test_from_file_v2_2_many_packets(tmpfile, data_packet_v2,
     packets = [data_packet_v2, config_read_packet_v2, timestamp_packet,
                message_packet, sync_packet, trigger_packet]
     to_file(tmpfile, packets, version='2.2')
-    new_packets_dict = from_file(tmpfile)
+    new_packets_dict = from_file(tmpfile, version='2.2')
     assert new_packets_dict['created']
     assert new_packets_dict['version']
     assert new_packets_dict['modified']
@@ -421,7 +421,7 @@ def test_from_file_v2_3_many_packets(tmpfile, data_packet_v2,
     packets = [data_packet_v2, config_read_packet_v2, timestamp_packet,
                message_packet, sync_packet, trigger_packet]
     to_file(tmpfile, packets, version='2.3')
-    new_packets_dict = from_file(tmpfile)
+    new_packets_dict = from_file(tmpfile, version='2.3')
     assert new_packets_dict['created']
     assert new_packets_dict['version']
     assert new_packets_dict['modified']
@@ -441,13 +441,13 @@ def test_to_file_v2_4_chips(tmpfile, chip):
     chips[0].config.pixel_trim_dac[12] = 0
     chips[1].config.threshold_global = 1
     to_file(tmpfile, chip_list=chips, version='2.4')
-    new_chips = from_file(tmpfile, load_configs=True)['configs']
+    new_chips = from_file(tmpfile, version='2.4', load_configs=True)['configs']
     assert [chip.chip_key for chip in chips] == [chip.chip_key for chip in new_chips]
     assert [chip.config for chip in chips] == [chip.config for chip in new_chips]
     assert new_chips[0].config.pixel_trim_dac[12] == chips[0].config.pixel_trim_dac[12]
     assert new_chips[1].config.threshold_global == chips[1].config.threshold_global
 
-    new_chips = from_file(tmpfile, load_configs=slice(1,4))['configs']
+    new_chips = from_file(tmpfile, version='2.4', load_configs=slice(1,4))['configs']
     assert len(new_chips) == 3
     assert new_chips[0].chip_key == chips[1].chip_key
 

--- a/test/test_hdf5format_direct.py
+++ b/test/test_hdf5format_direct.py
@@ -59,10 +59,10 @@ def test_direct_raw2packet(in_file_raw, out_file_indirect, out_file_direct):
 
     pkts = []
     for msg, io_group in zip(msgs, io_groups):
-        pkts.extend(parse(msg, io_group=io_group))
-    to_file(out_file_indirect, packet_list=pkts)
+        pkts.extend(parse(msg, io_group=io_group, asic_version=2))
+    to_file(out_file_indirect, packet_list=pkts, version='2.4')
 
-    to_file_direct(out_file_direct, msgs, io_groups)
+    to_file_direct(out_file_direct, msgs, io_groups, asic_version=2, version='2.4')
 
     pkts_indirect = h5py.File(out_file_indirect)['packets']
     pkts_direct = h5py.File(out_file_direct)['packets']

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -1752,7 +1752,9 @@ def test_controller_verify_configuration_ok(capfd, chip):
     controller.io = FakeIO()
     controller.chips[chip.chip_key] = chip
     conf_data = chip.get_configuration_packets(Packet.CONFIG_WRITE_PACKET)
-    for packet in conf_data: packet.packet_type = Packet.CONFIG_READ_PACKET
+    for packet in conf_data:
+        packet.packet_type = Packet.CONFIG_READ_PACKET
+        packet.assign_parity()
     controller.io.queue.append((conf_data,b'hi'))
     ok, diff = controller.verify_configuration(chip_keys=chip.chip_key)
     assert diff == {}
@@ -1763,7 +1765,9 @@ def test_controller_verify_configuration_missing_packet(capfd, chip):
     controller.io = FakeIO()
     controller.chips[chip.chip_key] = chip
     conf_data = chip.get_configuration_packets(Packet.CONFIG_WRITE_PACKET)
-    for packet in conf_data: packet.packet_type = Packet.CONFIG_READ_PACKET
+    for packet in conf_data:
+        packet.packet_type = Packet.CONFIG_READ_PACKET
+        packet.assign_parity()
     del conf_data[5]
     controller.io.queue.append((conf_data,b'hi'))
     ok, diff = controller.verify_configuration(chip_keys=chip.chip_key)
@@ -1775,8 +1779,11 @@ def test_controller_verify_configuration_bad_value(capfd, chip):
     controller.io = FakeIO()
     controller.chips[chip.chip_key] = chip
     conf_data = chip.get_configuration_packets(Packet.CONFIG_WRITE_PACKET)
-    for packet in conf_data: packet.packet_type = Packet.CONFIG_READ_PACKET
+    for packet in conf_data:
+        packet.packet_type = Packet.CONFIG_READ_PACKET
+        packet.assign_parity()
     conf_data[5].register_data = 17
+    conf_data[5].assign_parity()
     controller.io.queue.append((conf_data,b'hi'))
     ok, diff = controller.verify_configuration(chip_keys=chip.chip_key)
     assert ok == False

--- a/test/test_message_format.py
+++ b/test/test_message_format.py
@@ -9,8 +9,8 @@ def test_message_format_test_packets(chip):
     expected_messages += [b'\x01\x00'+b'T'+b'\x00'*5 + ts_packet.bytes() + b'\x00']
     print(expected_packets[-1])
     print(expected_messages[-1])
-    print(dataserver_message_decode(expected_messages)[-1])
+    print(dataserver_message_decode(expected_messages, asic_version=2)[-1])
     print(expected_messages[-1])
     print(dataserver_message_encode(expected_packets)[-1])
     assert expected_messages == dataserver_message_encode(expected_packets)
-    assert expected_packets == dataserver_message_decode(expected_messages)
+    assert expected_packets == dataserver_message_decode(expected_messages, asic_version=2)

--- a/test/test_multizmq_io.py
+++ b/test/test_multizmq_io.py
@@ -27,7 +27,7 @@ def io_config(tmpdir):
 
 @pytest.fixture
 def multizmq_io_obj(io_config):
-    return MultiZMQ_IO(io_config)
+    return MultiZMQ_IO(io_config, asic_version=2)
 
 def test_encode(multizmq_io_obj):
     chip_id = 64

--- a/test/test_scripts.py
+++ b/test/test_scripts.py
@@ -23,7 +23,7 @@ def test_packets():
 
 @pytest.fixture
 def raw_hdf5_tmpfile(tmpdir, test_packets):
-    msgs = [p_msg_fmt.format(pkts, asic_version=2) for pkts in test_packets]
+    msgs = [p_msg_fmt.format(pkts, msg_type='DATA', asic_version=2) for pkts in test_packets]
     io_groups = [0 for _ in test_packets]
 
     test_filename = os.path.join(tmpdir,'raw_test.h5')
@@ -51,7 +51,11 @@ def test_convert_rawhdf5_to_hdf5(tmpdir, raw_hdf5_tmpfile):
 
     # test read from file
     new_packets = p_h5_fmt.from_file(out_filename, version='2.4')['packets']
-    orig_packets = [p_msg_fmt.parse(msg, asic_version=2) for msg in r_h5_fmt.from_rawfile(raw_hdf5_tmpfile)['msgs']]
+    raw_data = r_h5_fmt.from_rawfile(raw_hdf5_tmpfile)
+    orig_packets = [
+        p_msg_fmt.parse(msg, io_group=io_group, asic_version=2)
+        for io_group, msg in zip(raw_data['msg_headers']['io_groups'], raw_data['msgs'])
+    ]
     assert new_packets == [p for pkts in orig_packets for p in pkts]
 
 def test_packet_hdf5_tool(tmpdir, packet_hdf5_tmpfile, test_packets):

--- a/test/test_scripts.py
+++ b/test/test_scripts.py
@@ -23,7 +23,7 @@ def test_packets():
 
 @pytest.fixture
 def raw_hdf5_tmpfile(tmpdir, test_packets):
-    msgs = [p_msg_fmt.format([pkts]) for pkts in test_packets]
+    msgs = [p_msg_fmt.format(pkts, asic_version=2) for pkts in test_packets]
     io_groups = [0 for _ in test_packets]
 
     test_filename = os.path.join(tmpdir,'raw_test.h5')
@@ -37,20 +37,21 @@ def packet_hdf5_tmpfile(tmpdir, test_packets):
     test_filename = os.path.join(tmpdir,'datalog_test.h5')
     p_h5_fmt.to_file(
         test_filename,
-        packet_list=[p for pkts in test_packets for p in pkts]
+        packet_list=[p for pkts in test_packets for p in pkts],
+        version='2.4'
         )
     return test_filename
 
 def test_convert_rawhdf5_to_hdf5(tmpdir, raw_hdf5_tmpfile):
     out_filename = os.path.join(tmpdir, 'datalog_convert_test.h5')
     proc = subprocess.run(
-        ['python', os.path.join(_dir_,'../scripts/convert_rawhdf5_to_hdf5.py'), '-i', raw_hdf5_tmpfile, '-o', out_filename, '--block_size', '10'],
+        ['python', os.path.join(_dir_,'../scripts/convert_rawhdf5_to_hdf5.py'), '-i', raw_hdf5_tmpfile, '-o', out_filename, '--block_size', '10', '--asic-version', '2', '--format-version', '2.4'],
         check=True
         )
 
     # test read from file
-    new_packets = p_h5_fmt.from_file(out_filename)['packets']
-    orig_packets = [p_msg_fmt.parse(msg) for msg in r_h5_fmt.from_rawfile(raw_hdf5_tmpfile)['msgs']]
+    new_packets = p_h5_fmt.from_file(out_filename, version='2.4')['packets']
+    orig_packets = [p_msg_fmt.parse(msg, asic_version=2) for msg in r_h5_fmt.from_rawfile(raw_hdf5_tmpfile)['msgs']]
     assert new_packets == [p for pkts in orig_packets for p in pkts]
 
 def test_packet_hdf5_tool(tmpdir, packet_hdf5_tmpfile, test_packets):
@@ -63,9 +64,9 @@ def test_packet_hdf5_tool(tmpdir, packet_hdf5_tmpfile, test_packets):
         )
 
     # test read from file
-    orig_packets = p_h5_fmt.from_file(packet_hdf5_tmpfile)['packets']
-    orig_packets += p_h5_fmt.from_file(packet_hdf5_tmpfile)['packets']
-    new_packets = p_h5_fmt.from_file(out_filename)['packets']
+    orig_packets = p_h5_fmt.from_file(packet_hdf5_tmpfile, version='2.4')['packets']
+    orig_packets += p_h5_fmt.from_file(packet_hdf5_tmpfile, version='2.4')['packets']
+    new_packets = p_h5_fmt.from_file(out_filename, version='2.4')['packets']
     assert len(orig_packets) == len(new_packets)
     assert orig_packets == new_packets
 

--- a/test/test_tutorial.py
+++ b/test/test_tutorial.py
@@ -170,11 +170,11 @@ def test_tutorial(capsys, tmpdir, temp_logfilename):
 
 
     from larpix.logger import HDF5Logger
-    controller.logger = HDF5Logger(filename=temp_logfilename, directory=str(tmpdir), buffer_length=10000) # a filename of None uses the default filename formatting
+    controller.logger = HDF5Logger(filename=temp_logfilename, directory=str(tmpdir), buffer_length=10000, version='2.4') # a filename of None uses the default filename formatting
     controller.logger.enable() # opens hdf5 file and starts tracking all communications
 
     controller.logger = HDF5Logger(filename=temp_logfilename,
-            directory=str(tmpdir), enabled=True)
+            directory=str(tmpdir), version='2.4', enabled=True)
 
     controller.verify_configuration()
     controller.logger.flush()
@@ -232,7 +232,7 @@ def test_running_with_pacman_v1r1():
     from larpix import Controller
     from larpix.io import PACMAN_IO
     controller = Controller()
-    controller.io = PACMAN_IO(config_filepath='io/pacman.json',timeout=1000)
+    controller.io = PACMAN_IO(config_filepath='io/pacman.json', timeout=1000, asic_version=2)
     controller.load('controller/network-3x3-tile-channel0.json')
     assert isinstance(controller.io.ping(),dict)
 

--- a/test/test_tutorial.py
+++ b/test/test_tutorial.py
@@ -220,7 +220,7 @@ def test_running_with_bern_daq_v1():
     from larpix.io import ZMQ_IO
 
     controller = Controller()
-    controller.io = ZMQ_IO(config_filepath='io/loopback.json')
+    controller.io = ZMQ_IO(config_filepath='io/loopback.json', asic_version=2)
 
     controller.load('controller/pcb-2_chip_info.json')
 

--- a/test/test_zmq_io.py
+++ b/test/test_zmq_io.py
@@ -16,6 +16,7 @@ def io_config(tmpdir):
     config_dict = {
             "_config_type": "io",
             "io_class": "ZMQ_IO",
+            "asic_version": 2,
             "io_group": [
                 [1, "192.0.2.1"]
             ]
@@ -26,7 +27,7 @@ def io_config(tmpdir):
 
 @pytest.fixture
 def zmq_io_obj(io_config):
-    return ZMQ_IO(io_config)
+    return ZMQ_IO(io_config, asic_version=2)
 
 def test_encode(zmq_io_obj):
     io_chain = 1


### PR DESCRIPTION
- Enforced explicit versioning: ASIC version is now required for PACMAN/MultiZMQ/message parsing paths, and HDF5 format version is required for logger/conversion/read-write flows.  
- Updated CLI and conversion workflows to require explicit `--asic-version` and `--format-version`, with clearer behavior and guidance.  
- Removed implicit packet-format assumptions in decode/format paths to prevent silent v2/v3 misinterpretation.  
- Standardized IO send interfaces to accept `msg_length` across base and backend IO classes.  
- Fixed tests to recompute parity after synthetic packet mutation.  
- Refreshed examples, README, and broad test coverage to match explicit-version contracts and new API expectations.